### PR TITLE
feat(format): integrate Embed into FormattedMessage content tree

### DIFF
--- a/chatom/base/conversion.py
+++ b/chatom/base/conversion.py
@@ -394,11 +394,6 @@ def demote(instance: BaseModel) -> BaseModel:
         raise ConversionError(f"Failed to demote {instance_type.__name__} to {base_type.__name__}: {e}")
 
 
-# =============================================================================
-# Backend type registration
-# =============================================================================
-
-
 def _register_all_types() -> None:
     """Register all known backend types from the backend registry.
 

--- a/chatom/base/message.py
+++ b/chatom/base/message.py
@@ -428,7 +428,7 @@ class Message(Identifiable):
             >>> formatted.render(Format.SLACK_MARKDOWN)
             'Hello *world*'
         """
-        from chatom.format import FormattedAttachment, FormattedMessage
+        from chatom.format import FormattedAttachment, FormattedEmbed, FormattedMessage
 
         fm = FormattedMessage()
 
@@ -450,6 +450,10 @@ class Message(Identifiable):
                     size=att.size,
                 )
             )
+
+        # Add embeds
+        for embed in self.embeds:
+            fm.embeds.append(FormattedEmbed(embed=embed))
 
         # Add metadata
         fm.metadata["source_backend"] = self.backend
@@ -512,10 +516,14 @@ class Message(Identifiable):
             for att in formatted.attachments
         ]
 
+        # Extract embeds
+        embeds = [fe.embed for fe in formatted.embeds]
+
         return cls(
             content=content,
             backend=backend,
             attachments=attachments,
+            embeds=embeds,
             metadata=dict(formatted.metadata),
             **kwargs,
         )

--- a/chatom/csp/nodes.py
+++ b/chatom/csp/nodes.py
@@ -361,9 +361,15 @@ def _send_messages_thread(msg_queue: Queue, backend: BackendBase):
 
                 log.debug(f"Sending message to channel_id={msg.channel_id}")
                 try:
+                    kwargs = {}
+                    if msg.attachments:
+                        kwargs["attachments"] = msg.attachments
+                    if msg.embeds:
+                        kwargs["embeds"] = msg.embeds
                     await thread_backend.send_message(
                         channel=msg.channel_id,
                         content=msg.content,
+                        **kwargs,
                     )
                     log.debug("Message sent successfully")
                 except Exception:

--- a/chatom/format/__init__.py
+++ b/chatom/format/__init__.py
@@ -17,6 +17,7 @@ from .components import (
     TextInput,
     TextInputStyle,
 )
+from .embed import FormattedEmbed
 from .message import (
     BACKEND_FORMAT_MAP,
     FormattedMessage,
@@ -115,6 +116,8 @@ __all__ = (
     # Attachment
     "FormattedAttachment",
     "FormattedImage",
+    # Embed
+    "FormattedEmbed",
     # Message
     "FormattedMessage",
     "MessageBuilder",

--- a/chatom/format/embed.py
+++ b/chatom/format/embed.py
@@ -1,0 +1,302 @@
+"""Embed formatting for chatom.
+
+This module provides the FormattedEmbed class — a content node that wraps
+the base Embed model and can be placed inside a FormattedMessage content tree.
+It renders a text fallback for all formats and exposes per-backend structured
+payloads via to_discord_dict(), to_slack_attachment(), and to_symphony_messageml().
+"""
+
+from typing import Any, Dict, List
+
+from pydantic import Field
+
+from chatom.base import BaseModel
+from chatom.base.embed import Embed
+
+from .variant import FORMAT, Format
+
+__all__ = ("FormattedEmbed",)
+
+
+class FormattedEmbed(BaseModel):
+    """A renderable embed content node for FormattedMessage.
+
+    Wraps the base ``Embed`` model so that embeds can appear alongside
+    Text, Table, and FormattedImage nodes in a message's content list.
+
+    ``render()`` produces a reasonable text fallback (bold title, field list)
+    for backends that don't support native embeds.  For backends that do,
+    callers should use the structured-payload methods instead:
+
+    * ``to_discord_dict()``  — Discord embed object
+    * ``to_slack_attachment()`` — Slack Block Kit attachment
+    * ``to_symphony_messageml()`` — Symphony ``<card>`` MessageML
+
+    Attributes:
+        embed: The underlying Embed data model.
+    """
+
+    embed: Embed = Field(default_factory=Embed, description="The underlying embed data.")
+
+    # ------------------------------------------------------------------
+    # Convenience constructors
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_embed(cls, embed: Embed) -> "FormattedEmbed":
+        """Create a FormattedEmbed from an existing Embed instance."""
+        return cls(embed=embed)
+
+    # ------------------------------------------------------------------
+    # Text fallback rendering (for content list)
+    # ------------------------------------------------------------------
+    def render(self, format: FORMAT = Format.MARKDOWN) -> str:
+        """Render the embed as a text fallback.
+
+        This is used when the embed appears in the content list and needs
+        to be converted to a flat string.  Backends that support native
+        embeds should use the structured-payload methods instead.
+        """
+        fmt = Format(format) if isinstance(format, str) else format
+        parts: List[str] = []
+
+        if self.embed.author:
+            parts.append(self._render_author(fmt))
+
+        if self.embed.title:
+            parts.append(self._render_title(fmt))
+
+        if self.embed.description:
+            parts.append(self.embed.description)
+
+        if self.embed.fields:
+            parts.append(self._render_fields(fmt))
+
+        if self.embed.image:
+            parts.append(self._render_image(fmt))
+
+        if self.embed.footer:
+            parts.append(self._render_footer(fmt))
+
+        return "\n".join(parts)
+
+    def _render_title(self, fmt: Format) -> str:
+        title = self.embed.title
+        if self.embed.url:
+            if fmt in (Format.MARKDOWN, Format.DISCORD_MARKDOWN):
+                title = f"[{title}]({self.embed.url})"
+            elif fmt == Format.SLACK_MARKDOWN:
+                title = f"<{self.embed.url}|{title}>"
+            elif fmt in (Format.HTML, Format.SYMPHONY_MESSAGEML):
+                title = f'<a href="{self.embed.url}">{title}</a>'
+
+        if fmt in (Format.MARKDOWN, Format.DISCORD_MARKDOWN):
+            return f"**{title}**"
+        elif fmt == Format.SLACK_MARKDOWN:
+            return f"*{title}*"
+        elif fmt in (Format.HTML, Format.SYMPHONY_MESSAGEML):
+            return f"<b>{title}</b>"
+        return title
+
+    def _render_author(self, fmt: Format) -> str:
+        author = self.embed.author
+        if not author:
+            return ""
+        name = author.name
+        if author.url:
+            if fmt in (Format.MARKDOWN, Format.DISCORD_MARKDOWN):
+                name = f"[{name}]({author.url})"
+            elif fmt == Format.SLACK_MARKDOWN:
+                name = f"<{author.url}|{name}>"
+            elif fmt in (Format.HTML, Format.SYMPHONY_MESSAGEML):
+                name = f'<a href="{author.url}">{name}</a>'
+        return name
+
+    def _render_fields(self, fmt: Format) -> str:
+        lines: List[str] = []
+        for field in self.embed.fields:
+            if fmt in (Format.MARKDOWN, Format.DISCORD_MARKDOWN):
+                lines.append(f"**{field.name}**: {field.value}")
+            elif fmt == Format.SLACK_MARKDOWN:
+                lines.append(f"*{field.name}*: {field.value}")
+            elif fmt in (Format.HTML, Format.SYMPHONY_MESSAGEML):
+                lines.append(f"<b>{field.name}</b>: {field.value}")
+            else:
+                lines.append(f"{field.name}: {field.value}")
+        return "\n".join(lines)
+
+    def _render_image(self, fmt: Format) -> str:
+        image = self.embed.image
+        if not image:
+            return ""
+        if fmt in (Format.MARKDOWN, Format.DISCORD_MARKDOWN):
+            return f"![image]({image.url})"
+        elif fmt == Format.SLACK_MARKDOWN:
+            return image.url
+        elif fmt == Format.HTML:
+            return f'<img src="{image.url}"/>'
+        elif fmt == Format.SYMPHONY_MESSAGEML:
+            return f'<img src="{image.url}"/>'
+        return image.url
+
+    def _render_footer(self, fmt: Format) -> str:
+        footer = self.embed.footer
+        if not footer:
+            return ""
+        if fmt in (Format.HTML, Format.SYMPHONY_MESSAGEML):
+            return f"<i>{footer.text}</i>"
+        elif fmt in (Format.MARKDOWN, Format.DISCORD_MARKDOWN):
+            return f"*{footer.text}*"
+        elif fmt == Format.SLACK_MARKDOWN:
+            return f"_{footer.text}_"
+        return footer.text
+
+    # ------------------------------------------------------------------
+    # Structured per-backend payloads
+    # ------------------------------------------------------------------
+    def to_discord_dict(self) -> Dict[str, Any]:
+        """Convert to a Discord embed dict suitable for the API."""
+        e = self.embed
+        data: Dict[str, Any] = {}
+        if e.title:
+            data["title"] = e.title
+        if e.description:
+            data["description"] = e.description
+        if e.url:
+            data["url"] = e.url
+        if e.color is not None:
+            data["color"] = e.color
+        if e.timestamp:
+            data["timestamp"] = e.timestamp.isoformat()
+        if e.author:
+            author: Dict[str, str] = {}
+            if e.author.name:
+                author["name"] = e.author.name
+            if e.author.url:
+                author["url"] = e.author.url
+            if e.author.icon_url:
+                author["icon_url"] = e.author.icon_url
+            data["author"] = author
+        if e.footer:
+            footer: Dict[str, str] = {}
+            if e.footer.text:
+                footer["text"] = e.footer.text
+            if e.footer.icon_url:
+                footer["icon_url"] = e.footer.icon_url
+            data["footer"] = footer
+        if e.thumbnail:
+            data["thumbnail"] = {"url": e.thumbnail.url}
+        if e.image:
+            data["image"] = {"url": e.image.url}
+        if e.fields:
+            data["fields"] = [{"name": f.name, "value": f.value, "inline": f.inline} for f in e.fields]
+        return data
+
+    def to_slack_attachment(self) -> Dict[str, Any]:
+        """Convert to a Slack Block Kit attachment dict."""
+        e = self.embed
+        attachment: Dict[str, Any] = {}
+        if e.color is not None:
+            attachment["color"] = f"#{e.color:06x}"
+        blocks: List[Dict[str, Any]] = []
+
+        # Title as a section header
+        if e.title:
+            title_text = e.title
+            if e.url:
+                title_text = f"<{e.url}|{e.title}>"
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": f"*{title_text}*"},
+                }
+            )
+
+        # Description
+        if e.description:
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": e.description},
+                }
+            )
+
+        # Fields — group into sections (max 10 fields per section in Slack)
+        if e.fields:
+            fields_list = [{"type": "mrkdwn", "text": f"*{f.name}*\n{f.value}"} for f in e.fields]
+            blocks.append(
+                {
+                    "type": "section",
+                    "fields": fields_list,
+                }
+            )
+
+        # Image
+        if e.image and e.image.url:
+            blocks.append(
+                {
+                    "type": "image",
+                    "image_url": e.image.url,
+                    "alt_text": "image",
+                }
+            )
+
+        # Footer as context block
+        if e.footer:
+            elements: List[Dict[str, Any]] = []
+            if e.footer.icon_url:
+                elements.append({"type": "image", "image_url": e.footer.icon_url, "alt_text": "footer icon"})
+            if e.footer.text:
+                elements.append({"type": "mrkdwn", "text": e.footer.text})
+            if elements:
+                blocks.append({"type": "context", "elements": elements})
+
+        # Author as context block at the top
+        if e.author:
+            author_elements: List[Dict[str, Any]] = []
+            if e.author.icon_url:
+                author_elements.append({"type": "image", "image_url": e.author.icon_url, "alt_text": "author icon"})
+            name = e.author.name
+            if e.author.url:
+                name = f"<{e.author.url}|{e.author.name}>"
+            author_elements.append({"type": "mrkdwn", "text": name})
+            blocks.insert(0, {"type": "context", "elements": author_elements})
+
+        attachment["blocks"] = blocks
+        return attachment
+
+    def to_symphony_messageml(self) -> str:
+        """Convert to Symphony MessageML ``<card>`` markup."""
+        e = self.embed
+        parts: List[str] = []
+
+        # Header
+        header_parts: List[str] = []
+        if e.title:
+            header_parts.append(e.title)
+        if e.author and e.author.name:
+            header_parts.append(f" — {e.author.name}")
+        header = "".join(header_parts) or "Embed"
+
+        parts.append(f'<card accent="tempo-bg-color--blue"><header>{header}</header><body>')
+
+        if e.description:
+            parts.append(f"<p>{e.description}</p>")
+
+        if e.fields:
+            parts.append("<table><thead><tr><td>Field</td><td>Value</td></tr></thead><tbody>")
+            for f in e.fields:
+                parts.append(f"<tr><td>{f.name}</td><td>{f.value}</td></tr>")
+            parts.append("</tbody></table>")
+
+        if e.image and e.image.url:
+            parts.append(f'<img src="{e.image.url}"/>')
+
+        if e.footer and e.footer.text:
+            parts.append(f"<p><i>{e.footer.text}</i></p>")
+
+        parts.append("</body></card>")
+        return "".join(parts)
+
+    def to_telegram_html(self) -> str:
+        """Convert to Telegram-compatible HTML."""
+        return self.render(Format.HTML)

--- a/chatom/format/message.py
+++ b/chatom/format/message.py
@@ -12,6 +12,7 @@ from chatom.base import BaseModel
 
 from .attachment import FormattedAttachment, FormattedImage
 from .components import ActionRow, Button, ButtonStyle, ComponentContainer, SelectOption
+from .embed import FormattedEmbed
 from .table import Table
 from .text import (
     Bold,
@@ -37,6 +38,7 @@ from .variant import FORMAT, Format
 
 if TYPE_CHECKING:
     from chatom.base import Channel, User
+    from chatom.base.embed import Embed
 
 __all__ = (
     "FormattedMessage",
@@ -96,13 +98,17 @@ class FormattedMessage(BaseModel):
         metadata: Additional platform-specific metadata.
     """
 
-    content: List[Union[TextNode, Table, FormattedImage, FormattedAttachment]] = Field(
+    content: List[Union[TextNode, Table, FormattedImage, FormattedAttachment, FormattedEmbed]] = Field(
         default_factory=list,
         description="Content nodes.",
     )
     attachments: List[FormattedAttachment] = Field(
         default_factory=list,
         description="File attachments.",
+    )
+    embeds: List[FormattedEmbed] = Field(
+        default_factory=list,
+        description="Rich embeds (rendered natively on supported backends).",
     )
     components: Optional[ComponentContainer] = Field(
         default=None,
@@ -385,6 +391,81 @@ class FormattedMessage(BaseModel):
 
         return self.components.add_row()
 
+    def add_embed(
+        self,
+        embed: "Optional[Embed]" = None,
+        *,
+        title: str = "",
+        description: str = "",
+        color: Optional[int] = None,
+        url: str = "",
+        inline: bool = False,
+    ) -> "FormattedMessage":
+        """Add a rich embed to the message.
+
+        You can pass an existing ``Embed`` instance, or provide keyword
+        arguments to create one.
+
+        Args:
+            embed: An existing Embed to wrap.
+            title: Embed title (used when *embed* is None).
+            description: Embed description.
+            color: Sidebar colour as a hex integer.
+            url: URL the title links to.
+            inline: If True the embed is also appended to ``content``
+                so it appears inline in the text fallback.
+
+        Returns:
+            Self for method chaining.
+        """
+        if embed is None:
+            from chatom.base.embed import Embed as BaseEmbed
+
+            embed = BaseEmbed(title=title, description=description, color=color, url=url)
+        fe = FormattedEmbed(embed=embed)
+        self.embeds.append(fe)
+        if inline:
+            self.content.append(fe)
+        return self
+
+    def get_embeds(self, format: FORMAT = Format.MARKDOWN) -> List[Dict[str, Any]]:
+        """Get structured embed payloads for the specified format.
+
+        Returns a list of dicts suitable for passing to the backend API.
+        For formats/backends that do not support structured embeds the
+        list is empty — use ``render()`` for the text fallback.
+
+        Args:
+            format: The target output format.
+
+        Returns:
+            List of backend-specific embed dicts.
+        """
+        fmt = Format(format) if isinstance(format, str) else format
+        result: List[Dict[str, Any]] = []
+        for fe in self.embeds:
+            if fmt == Format.DISCORD_MARKDOWN:
+                result.append(fe.to_discord_dict())
+            elif fmt == Format.SLACK_MARKDOWN:
+                result.append(fe.to_slack_attachment())
+            elif fmt == Format.SYMPHONY_MESSAGEML:
+                result.append({"messageml": fe.to_symphony_messageml()})
+            elif fmt == Format.HTML:
+                result.append({"html": fe.to_telegram_html()})
+        return result
+
+    def get_embeds_for(self, backend: str) -> List[Dict[str, Any]]:
+        """Get structured embed payloads for a specific backend.
+
+        Args:
+            backend: Backend identifier (e.g. 'discord', 'slack').
+
+        Returns:
+            List of backend-specific embed dicts.
+        """
+        fmt = get_format_for_backend(backend)
+        return self.get_embeds(fmt)
+
     def get_components(self, format: FORMAT = Format.MARKDOWN) -> List[Dict[str, Any]]:
         """Get rendered components for the specified format.
 
@@ -415,8 +496,9 @@ class MessageBuilder:
     """
 
     def __init__(self):
-        self._content: List[Union[TextNode, Table, FormattedImage, FormattedAttachment]] = []
+        self._content: List[Union[TextNode, Table, FormattedImage, FormattedAttachment, FormattedEmbed]] = []
         self._attachments: List[FormattedAttachment] = []
+        self._embeds: List[FormattedEmbed] = []
         self._metadata: Dict[str, Any] = {}
 
     def text(self, content: str) -> "MessageBuilder":
@@ -522,6 +604,11 @@ class MessageBuilder:
         self._content.append(node)
         return self
 
+    def embed(self, embed: "Embed") -> "MessageBuilder":
+        """Add a rich embed."""
+        self._embeds.append(FormattedEmbed(embed=embed))
+        return self
+
     def metadata(self, key: str, value: Any) -> "MessageBuilder":
         """Add metadata."""
         self._metadata[key] = value
@@ -536,6 +623,7 @@ class MessageBuilder:
         return FormattedMessage(
             content=self._content.copy(),
             attachments=self._attachments.copy(),
+            embeds=self._embeds.copy(),
             metadata=self._metadata.copy(),
         )
 

--- a/chatom/tests/test_csp.py
+++ b/chatom/tests/test_csp.py
@@ -33,13 +33,15 @@ class MockBackendConfig:
 # Class-level storage for tracking messages across all MockBackendForCSP instances
 # This is needed because CSP nodes create new backend instances per thread
 _mock_sent_messages: List[Message] = []
+_mock_sent_kwargs: List[dict] = []
 _mock_presence_updates: List[str] = []
 
 
 def reset_mock_tracking():
     """Reset class-level message tracking."""
-    global _mock_sent_messages, _mock_presence_updates
+    global _mock_sent_messages, _mock_sent_kwargs, _mock_presence_updates
     _mock_sent_messages = []
+    _mock_sent_kwargs = []
     _mock_presence_updates = []
 
 
@@ -85,6 +87,7 @@ class MockBackendForCSP:
             author=User(id=self._bot_user_id),
         )
         _mock_sent_messages.append(msg)
+        _mock_sent_kwargs.append(kwargs)
         return msg
 
     async def set_presence(self, status: str):
@@ -356,6 +359,77 @@ class TestSendMessagesThread:
         thread.join(timeout=2.0)
 
         assert len(mock_backend.sent_messages) == 5
+
+    def test_send_message_with_attachments(self, mock_backend):
+        """Test that attachments are forwarded as kwargs to send_message."""
+        from chatom.base.attachment import Attachment
+
+        queue = Queue()
+        thread = threading.Thread(
+            target=_send_messages_thread,
+            args=(queue, mock_backend),
+            daemon=True,
+        )
+        thread.start()
+
+        att = Attachment(filename="report.pdf", url="https://example.com/report.pdf")
+        msg = Message(
+            channel=Channel(id="C123"),
+            content="Here's the report",
+            attachments=[att],
+        )
+        queue.put(msg)
+        queue.put(None)
+        queue.join()
+        thread.join(timeout=2.0)
+
+        assert len(mock_backend.sent_messages) == 1
+        assert _mock_sent_kwargs[0]["attachments"] == [att]
+
+    def test_send_message_with_embeds(self, mock_backend):
+        """Test that embeds are forwarded as kwargs to send_message."""
+        from chatom.base.embed import Embed
+
+        queue = Queue()
+        thread = threading.Thread(
+            target=_send_messages_thread,
+            args=(queue, mock_backend),
+            daemon=True,
+        )
+        thread.start()
+
+        embed = Embed(title="Status", description="All good")
+        msg = Message(
+            channel=Channel(id="C123"),
+            content="Status update",
+            embeds=[embed],
+        )
+        queue.put(msg)
+        queue.put(None)
+        queue.join()
+        thread.join(timeout=2.0)
+
+        assert len(mock_backend.sent_messages) == 1
+        assert _mock_sent_kwargs[0]["embeds"] == [embed]
+
+    def test_send_message_without_attachments_no_kwargs(self, mock_backend):
+        """Test that no extra kwargs are passed when there are no attachments."""
+        queue = Queue()
+        thread = threading.Thread(
+            target=_send_messages_thread,
+            args=(queue, mock_backend),
+            daemon=True,
+        )
+        thread.start()
+
+        msg = Message(channel=Channel(id="C123"), content="Plain message")
+        queue.put(msg)
+        queue.put(None)
+        queue.join()
+        thread.join(timeout=2.0)
+
+        assert len(mock_backend.sent_messages) == 1
+        assert _mock_sent_kwargs[0] == {}
 
 
 class TestCSPGraphExecution:

--- a/chatom/tests/test_format.py
+++ b/chatom/tests/test_format.py
@@ -15,6 +15,7 @@ from chatom.format import (
     # Variant/Format
     Format,
     FormattedAttachment,
+    FormattedEmbed,
     FormattedImage,
     # Message formatting
     FormattedMessage,
@@ -2479,3 +2480,268 @@ class TestActionRowGeneric:
         row = ActionRow(components=[menu])
         result = row.render(Format.SYMPHONY_MESSAGEML)
         assert "<select" in result["messageml"]
+
+
+# -------------------------------------------------------------------------
+# Phase 1: Embed / FormattedEmbed tests
+# -------------------------------------------------------------------------
+
+
+class TestFormattedEmbed:
+    """Tests for the FormattedEmbed content node."""
+
+    def _make_embed(self):
+        from chatom.base.embed import Embed, EmbedAuthor, EmbedField, EmbedFooter, EmbedMedia
+
+        return Embed(
+            title="Bot Status",
+            description="All systems operational.",
+            url="https://example.com/status",
+            color=0x00FF00,
+            author=EmbedAuthor(name="Chatom", url="https://chatom.dev"),
+            footer=EmbedFooter(text="Last updated"),
+            image=EmbedMedia(url="https://example.com/img.png"),
+            fields=[
+                EmbedField(name="Uptime", value="3d 12h", inline=True),
+                EmbedField(name="Commands", value="567", inline=True),
+            ],
+        )
+
+    # -- text fallback rendering --
+
+    def test_render_markdown(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        rendered = fe.render(Format.MARKDOWN)
+        assert "**Bot Status**" in rendered or "**[Bot Status]" in rendered
+        assert "**Uptime**: 3d 12h" in rendered
+        assert "**Commands**: 567" in rendered
+        assert "Last updated" in rendered
+
+    def test_render_slack(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        rendered = fe.render(Format.SLACK_MARKDOWN)
+        assert "*Uptime*: 3d 12h" in rendered
+        assert "_Last updated_" in rendered
+
+    def test_render_html(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        rendered = fe.render(Format.HTML)
+        assert "<b>" in rendered
+        assert "Bot Status" in rendered
+
+    def test_render_symphony(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        rendered = fe.render(Format.SYMPHONY_MESSAGEML)
+        assert "<b>" in rendered
+
+    def test_render_plaintext(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        rendered = fe.render(Format.PLAINTEXT)
+        assert "Uptime: 3d 12h" in rendered
+
+    # -- structured payloads --
+
+    def test_to_discord_dict(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        d = fe.to_discord_dict()
+        assert d["title"] == "Bot Status"
+        assert d["description"] == "All systems operational."
+        assert d["url"] == "https://example.com/status"
+        assert d["color"] == 0x00FF00
+        assert d["author"]["name"] == "Chatom"
+        assert d["footer"]["text"] == "Last updated"
+        assert d["image"]["url"] == "https://example.com/img.png"
+        assert len(d["fields"]) == 2
+        assert d["fields"][0] == {"name": "Uptime", "value": "3d 12h", "inline": True}
+
+    def test_to_slack_attachment(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        att = fe.to_slack_attachment()
+        assert att["color"] == "#00ff00"
+        assert "blocks" in att
+        blocks = att["blocks"]
+        # Should have author context, title section, description, fields, image, footer
+        types = [b["type"] for b in blocks]
+        assert "section" in types
+        assert "context" in types
+
+    def test_to_symphony_messageml(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        ml = fe.to_symphony_messageml()
+        assert "<card" in ml
+        assert "<header>" in ml
+        assert "Bot Status" in ml
+        assert "<table>" in ml
+        assert "Uptime" in ml
+        assert "</card>" in ml
+
+    def test_to_telegram_html(self):
+        fe = FormattedEmbed(embed=self._make_embed())
+        html = fe.to_telegram_html()
+        assert "<b>" in html
+        assert "Bot Status" in html
+
+    # -- from_embed factory --
+
+    def test_from_embed(self):
+        from chatom.base.embed import Embed
+
+        e = Embed(title="Test")
+        fe = FormattedEmbed.from_embed(e)
+        assert fe.embed.title == "Test"
+
+
+class TestFormattedMessageEmbeds:
+    """Tests for embed integration in FormattedMessage."""
+
+    def _make_embed(self):
+        from chatom.base.embed import Embed, EmbedField
+
+        return Embed(
+            title="Status",
+            color=0x00FF00,
+            fields=[EmbedField(name="Uptime", value="3d", inline=True)],
+        )
+
+    def test_add_embed_with_existing_embed(self):
+        msg = FormattedMessage()
+        msg.add_embed(self._make_embed())
+        assert len(msg.embeds) == 1
+        assert msg.embeds[0].embed.title == "Status"
+
+    def test_add_embed_with_kwargs(self):
+        msg = FormattedMessage()
+        msg.add_embed(title="Quick", description="desc", color=0xFF0000)
+        assert len(msg.embeds) == 1
+        assert msg.embeds[0].embed.title == "Quick"
+        assert msg.embeds[0].embed.description == "desc"
+
+    def test_add_embed_inline(self):
+        msg = FormattedMessage()
+        msg.add_text("Before: ")
+        msg.add_embed(self._make_embed(), inline=True)
+        assert len(msg.embeds) == 1
+        assert len(msg.content) == 2  # Text + FormattedEmbed
+        rendered = msg.render(Format.MARKDOWN)
+        assert "Uptime" in rendered
+
+    def test_add_embed_not_inline_by_default(self):
+        msg = FormattedMessage()
+        msg.add_embed(self._make_embed())
+        assert len(msg.content) == 0
+        assert len(msg.embeds) == 1
+
+    def test_get_embeds_discord(self):
+        msg = FormattedMessage()
+        msg.add_embed(self._make_embed())
+        embeds = msg.get_embeds(Format.DISCORD_MARKDOWN)
+        assert len(embeds) == 1
+        assert embeds[0]["title"] == "Status"
+
+    def test_get_embeds_slack(self):
+        msg = FormattedMessage()
+        msg.add_embed(self._make_embed())
+        embeds = msg.get_embeds(Format.SLACK_MARKDOWN)
+        assert len(embeds) == 1
+        assert "blocks" in embeds[0]
+
+    def test_get_embeds_symphony(self):
+        msg = FormattedMessage()
+        msg.add_embed(self._make_embed())
+        embeds = msg.get_embeds(Format.SYMPHONY_MESSAGEML)
+        assert len(embeds) == 1
+        assert "<card" in embeds[0]["messageml"]
+
+    def test_get_embeds_html(self):
+        msg = FormattedMessage()
+        msg.add_embed(self._make_embed())
+        embeds = msg.get_embeds(Format.HTML)
+        assert len(embeds) == 1
+        assert "html" in embeds[0]
+
+    def test_get_embeds_for_backend(self):
+        msg = FormattedMessage()
+        msg.add_embed(self._make_embed())
+        embeds = msg.get_embeds_for("discord")
+        assert len(embeds) == 1
+        assert embeds[0]["title"] == "Status"
+
+    def test_get_embeds_empty_for_plaintext(self):
+        msg = FormattedMessage()
+        msg.add_embed(self._make_embed())
+        embeds = msg.get_embeds(Format.PLAINTEXT)
+        assert embeds == []
+
+    def test_render_for_with_inline_embed(self):
+        msg = FormattedMessage()
+        msg.add_text("Status: ")
+        msg.add_embed(self._make_embed(), inline=True)
+        for backend in ("slack", "discord", "symphony"):
+            rendered = msg.render_for(backend)
+            assert "Uptime" in rendered
+
+    def test_multiple_embeds(self):
+        msg = FormattedMessage()
+        msg.add_embed(title="First", color=0xFF0000)
+        msg.add_embed(title="Second", color=0x00FF00)
+        assert len(msg.embeds) == 2
+        embeds = msg.get_embeds(Format.DISCORD_MARKDOWN)
+        assert embeds[0]["title"] == "First"
+        assert embeds[1]["title"] == "Second"
+
+
+class TestMessageBuilderEmbed:
+    """Tests for embed support in MessageBuilder."""
+
+    def test_builder_embed(self):
+        from chatom.base.embed import Embed, EmbedField
+
+        e = Embed(title="Built", fields=[EmbedField(name="K", value="V")])
+        msg = MessageBuilder().text("Hi ").embed(e).build()
+        assert len(msg.embeds) == 1
+        assert msg.embeds[0].embed.title == "Built"
+
+    def test_builder_embed_get_embeds(self):
+        from chatom.base.embed import Embed
+
+        e = Embed(title="T")
+        msg = MessageBuilder().embed(e).build()
+        embeds = msg.get_embeds(Format.DISCORD_MARKDOWN)
+        assert len(embeds) == 1
+        assert embeds[0]["title"] == "T"
+
+
+class TestMessageEmbedRoundTrip:
+    """Tests for Message <-> FormattedMessage embed round-trip."""
+
+    def test_to_formatted_includes_embeds(self):
+        from chatom.base import Embed, Message
+
+        e = Embed(title="Status")
+        msg = Message(content="Hi", embeds=[e], backend="discord")
+        fm = msg.to_formatted()
+        assert len(fm.embeds) == 1
+        assert fm.embeds[0].embed.title == "Status"
+
+    def test_from_formatted_includes_embeds(self):
+        from chatom.base import Message
+        from chatom.base.embed import Embed
+
+        fm = FormattedMessage()
+        fm.add_text("Hello")
+        fm.add_embed(Embed(title="Info"))
+        msg = Message.from_formatted(fm, backend="discord")
+        assert len(msg.embeds) == 1
+        assert msg.embeds[0].title == "Info"
+
+    def test_round_trip_preserves_embed(self):
+        from chatom.base import Embed, Message
+
+        e = Embed(title="RT", description="Round trip test")
+        e.add_field("K", "V", inline=True)
+        original = Message(content="Test", embeds=[e], backend="slack")
+        fm = original.to_formatted()
+        restored = Message.from_formatted(fm, backend="slack")
+        assert len(restored.embeds) == 1
+        assert restored.embeds[0].title == "RT"
+        assert restored.embeds[0].fields[0].name == "K"


### PR DESCRIPTION
Add FormattedEmbed as a renderable content node that wraps the base Embed model, enabling embeds alongside Text, Table, and Image nodes in messages.

- Add format/embed.py with FormattedEmbed: text fallback render() plus structured payloads via to_discord_dict(), to_slack_attachment(), to_symphony_messageml(), and to_telegram_html()
- Add embeds field, add_embed(), get_embeds(), get_embeds_for() to FormattedMessage; add embed() to MessageBuilder
- Wire Message.to_formatted() and Message.from_formatted() to carry embeds through the conversion round-trip
- Export FormattedEmbed from chatom.format
- Add 27 tests covering rendering, structured payloads, FM integration, builder, and Message round-trip
