### PR TITLE
feat(media): add binary upload support and per-backend upload_file

### DIFF
--- a/chatom/backend/backend.py
+++ b/chatom/backend/backend.py
@@ -921,6 +921,39 @@ class BackendBase(BaseModel):
         """
         raise NotImplementedError("This backend does not support message editing")
 
+    async def upload_file(
+        self,
+        channel: Union[str, Channel],
+        data: bytes,
+        filename: str = "file",
+        content_type: str = "",
+        title: str = "",
+        content: str = "",
+        **kwargs: Any,
+    ) -> Message:
+        """Upload a file with binary data to a channel.
+
+        Backends should override this to use their native file upload API
+        (e.g. Slack ``files.uploadV2``, Discord ``File``, Telegram
+        ``send_document`` / ``send_photo``, Symphony attachment API).
+
+        The default implementation falls back to ``send_message`` with
+        a text-only placeholder.
+
+        Args:
+            channel: The channel to upload to (ID string or Channel object).
+            data: Raw file bytes.
+            filename: Name of the file.
+            content_type: MIME type of the file.
+            title: Optional title for the upload.
+            content: Optional accompanying text message.
+            **kwargs: Additional platform-specific options.
+
+        Returns:
+            The sent message.
+        """
+        raise NotImplementedError("This backend does not support file uploads")
+
     async def delete_message(
         self,
         message: Union[str, Message],

--- a/chatom/base/attachment.py
+++ b/chatom/base/attachment.py
@@ -46,6 +46,7 @@ class Attachment(BaseModel):
         id: Platform-specific unique identifier.
         filename: Name of the file.
         url: URL to download the attachment.
+        data: Raw file bytes for direct upload.
         content_type: MIME type of the attachment.
         size: File size in bytes.
         attachment_type: Type of attachment.
@@ -63,6 +64,12 @@ class Attachment(BaseModel):
         default="",
         description="URL to download the attachment.",
     )
+    data: Optional[bytes] = Field(
+        default=None,
+        description="Raw file bytes for direct upload.",
+        exclude=True,
+        repr=False,
+    )
     content_type: str = Field(
         default="",
         description="MIME type of the attachment.",
@@ -75,6 +82,11 @@ class Attachment(BaseModel):
         default=AttachmentType.UNKNOWN,
         description="Type of attachment.",
     )
+
+    @property
+    def has_data(self) -> bool:
+        """Whether this attachment carries in-memory binary data."""
+        return self.data is not None
 
     @classmethod
     def from_content_type(cls, content_type: str) -> AttachmentType:

--- a/chatom/base/message.py
+++ b/chatom/base/message.py
@@ -446,6 +446,7 @@ class Message(Identifiable):
                 FormattedAttachment(
                     filename=att.filename,
                     url=att.url,
+                    data=att.data,
                     content_type=att.content_type,
                     size=att.size,
                 )
@@ -510,6 +511,7 @@ class Message(Identifiable):
             Attachment(
                 filename=att.filename,
                 url=att.url,
+                data=att.data,
                 content_type=att.content_type,
                 size=att.size,
             )

--- a/chatom/csp/nodes.py
+++ b/chatom/csp/nodes.py
@@ -361,9 +361,19 @@ def _send_messages_thread(msg_queue: Queue, backend: BackendBase):
 
                 log.debug(f"Sending message to channel_id={msg.channel_id}")
                 try:
+                    # Separate attachments with binary data from URL-only ones
+                    url_attachments = []
+                    upload_attachments = []
+                    for att in msg.attachments:
+                        if getattr(att, "has_data", False) and att.data is not None:
+                            upload_attachments.append(att)
+                        else:
+                            url_attachments.append(att)
+
+                    # Send the main message (text + url attachments + embeds)
                     kwargs = {}
-                    if msg.attachments:
-                        kwargs["attachments"] = msg.attachments
+                    if url_attachments:
+                        kwargs["attachments"] = url_attachments
                     if msg.embeds:
                         kwargs["embeds"] = msg.embeds
                     await thread_backend.send_message(
@@ -371,6 +381,21 @@ def _send_messages_thread(msg_queue: Queue, backend: BackendBase):
                         content=msg.content,
                         **kwargs,
                     )
+
+                    # Upload any attachments with binary data
+                    for att in upload_attachments:
+                        try:
+                            await thread_backend.upload_file(
+                                channel=msg.channel_id,
+                                data=att.data,
+                                filename=att.filename or "file",
+                                content_type=getattr(att, "content_type", ""),
+                            )
+                        except NotImplementedError:
+                            log.warning(f"Backend {type(thread_backend).__name__} does not support file uploads, skipping {att.filename!r}")
+                        except Exception:
+                            log.exception(f"Failed uploading {att.filename!r}")
+
                     log.debug("Message sent successfully")
                 except Exception:
                     log.exception("Failed sending message")

--- a/chatom/discord/backend.py
+++ b/chatom/discord/backend.py
@@ -551,6 +551,46 @@ class DiscordBackend(BackendBase):
         except (discord.NotFound, discord.HTTPException, ValueError) as e:
             raise RuntimeError(f"Failed to send message: {e}") from e
 
+    async def upload_file(
+        self,
+        channel: Union[str, Channel],
+        data: bytes,
+        filename: str = "file",
+        content_type: str = "",
+        title: str = "",
+        content: str = "",
+        **kwargs: Any,
+    ) -> Message:
+        """Upload a file to a Discord channel.
+
+        Uses ``discord.File`` to send binary data directly.
+        """
+        import io
+
+        if self._client is None:
+            raise RuntimeError("Not connected to Discord")
+
+        channel_id = await self._resolve_channel_id(channel)
+
+        try:
+            discord_channel = await self._client.fetch_channel(int(channel_id))
+            if discord_channel is None:
+                raise RuntimeError(f"Channel {channel_id} not found")
+
+            file_obj = discord.File(fp=io.BytesIO(data), filename=filename)
+            msg = await discord_channel.send(content=content or None, file=file_obj)
+
+            return DiscordMessage(
+                id=str(msg.id),
+                content=msg.content or "",
+                created_at=msg.created_at.replace(tzinfo=timezone.utc) if msg.created_at else datetime.now(timezone.utc),
+                author=DiscordUser(id=str(msg.author.id)),
+                channel=DiscordChannel(id=str(msg.channel.id)),
+                guild=Organization(id=str(msg.guild.id)) if msg.guild else None,
+            )
+        except (discord.NotFound, discord.HTTPException, ValueError) as e:
+            raise RuntimeError(f"Failed to upload file: {e}") from e
+
     async def edit_message(
         self,
         message: Union[str, Message],

--- a/chatom/format/attachment.py
+++ b/chatom/format/attachment.py
@@ -1,6 +1,8 @@
 """Attachment formatting for chatom.
 
 This module provides attachment and media rendering for different formats.
+Attachments can reference files by URL or hold in-memory binary data
+for direct upload to backend APIs.
 """
 
 from typing import Optional
@@ -17,17 +19,28 @@ __all__ = ("FormattedAttachment", "FormattedImage")
 class FormattedAttachment(BaseModel):
     """An attachment that can be rendered to different formats.
 
+    Attachments can reference a URL or hold raw bytes for upload.
+    When ``data`` is set, the publish path will use the backend's
+    file upload API instead of rendering a URL link.
+
     Attributes:
         filename: Name of the file.
         url: URL to the attachment.
+        data: Raw file bytes for direct upload.
         size: File size in bytes.
         content_type: MIME type.
     """
 
     filename: str = Field(default="", description="Name of the file.")
     url: str = Field(default="", description="URL to the attachment.")
+    data: Optional[bytes] = Field(default=None, description="Raw file bytes for direct upload.", exclude=True, repr=False)
     size: Optional[int] = Field(default=None, description="File size in bytes.")
     content_type: str = Field(default="", description="MIME type.")
+
+    @property
+    def has_data(self) -> bool:
+        """Whether this attachment carries in-memory binary data."""
+        return self.data is not None
 
     def render(self, format: FORMAT = Format.MARKDOWN) -> str:
         """Render the attachment to the specified format.
@@ -53,19 +66,34 @@ class FormattedAttachment(BaseModel):
 class FormattedImage(BaseModel):
     """An image that can be rendered to different formats.
 
+    Images can reference a URL or hold raw bytes for upload.
+    When ``data`` is set, the publish path will use the backend's
+    image/file upload API instead of rendering a URL.
+
     Attributes:
         url: URL to the image.
+        data: Raw image bytes for direct upload.
         alt_text: Alternative text for accessibility.
         title: Image title.
+        filename: Filename for the upload (derived from url if empty).
+        content_type: MIME type (e.g. ``image/png``).
         width: Width in pixels.
         height: Height in pixels.
     """
 
     url: str = Field(default="", description="URL to the image.")
+    data: Optional[bytes] = Field(default=None, description="Raw image bytes for direct upload.", exclude=True, repr=False)
     alt_text: str = Field(default="", description="Alternative text.")
     title: str = Field(default="", description="Image title.")
+    filename: str = Field(default="", description="Filename for the upload.")
+    content_type: str = Field(default="", description="MIME type (e.g. image/png).")
     width: Optional[int] = Field(default=None, description="Width in pixels.")
     height: Optional[int] = Field(default=None, description="Height in pixels.")
+
+    @property
+    def has_data(self) -> bool:
+        """Whether this image carries in-memory binary data."""
+        return self.data is not None
 
     def render(self, format: FORMAT = Format.MARKDOWN) -> str:
         """Render the image to the specified format.

--- a/chatom/slack/backend.py
+++ b/chatom/slack/backend.py
@@ -558,6 +558,48 @@ class SlackBackend(BackendBase):
         msg_data["ts"] = response.get("ts", msg_data.get("ts", ""))
         return self._parse_slack_message(msg_data, channel_id)
 
+    async def upload_file(
+        self,
+        channel: Union[str, Channel],
+        data: bytes,
+        filename: str = "file",
+        content_type: str = "",
+        title: str = "",
+        content: str = "",
+        **kwargs: Any,
+    ) -> Message:
+        """Upload a file to a Slack channel.
+
+        Uses the ``files_upload_v2`` API (Slack SDK >=3.19).
+        """
+        self._ensure_connected()
+
+        channel_id = await self._resolve_channel_id(channel)
+
+        upload_kwargs: dict[str, Any] = {
+            "channel": channel_id,
+            "content": data,
+            "filename": filename,
+        }
+        if title:
+            upload_kwargs["title"] = title
+        if content:
+            upload_kwargs["initial_comment"] = content
+
+        response = await self._async_client.files_upload_v2(**upload_kwargs)
+
+        if not response.get("ok"):
+            raise RuntimeError(f"Failed to upload file: {response.get('error')}")
+
+        # Return a minimal message — Slack file uploads don't always
+        # return a message payload in the same shape as chat.postMessage
+        return SlackMessage(
+            id=response.get("file", {}).get("id", ""),
+            content=content,
+            channel=SlackChannel(id=channel_id),
+            backend="slack",
+        )
+
     async def edit_message(
         self,
         message: Union[str, Message],

--- a/chatom/symphony/backend.py
+++ b/chatom/symphony/backend.py
@@ -5,6 +5,7 @@ This module provides the Symphony backend using the Symphony BDK
 """
 
 import asyncio
+import contextlib
 import logging
 from datetime import datetime, timezone
 from typing import Any, AsyncIterator, ClassVar, List, Optional, Union
@@ -624,6 +625,60 @@ class SymphonyBackend(BackendBase):
 
         except Exception as e:
             raise RuntimeError(f"Failed to send message: {e}") from e
+
+    async def upload_file(
+        self,
+        channel: Union[str, Channel],
+        data: bytes,
+        filename: str = "file",
+        content_type: str = "",
+        title: str = "",
+        content: str = "",
+        **kwargs: Any,
+    ) -> Message:
+        """Upload a file to a Symphony stream.
+
+        Sends the file as an attachment via the Symphony BDK message API.
+        The binary data is written to a temporary file which is passed to
+        the BDK's attachment parameter.
+        """
+        import os
+        import tempfile
+
+        if self._bdk is None:
+            raise RuntimeError("Symphony not connected")
+
+        channel_id = await self._resolve_channel_id(channel)
+
+        # Symphony BDK expects file paths for attachments, so write to temp
+        fd, tmp_path = tempfile.mkstemp(suffix=f"_{filename}")
+        try:
+            os.write(fd, data)
+            os.close(fd)
+
+            message_service = self._bdk.messages()
+            body = content or title or filename
+            if not body.strip().startswith("<messageML>"):
+                body = f"<messageML>{body}</messageML>"
+
+            result = await message_service.send_message(
+                stream_id=channel_id,
+                message=body,
+                attachment=[tmp_path],
+            )
+
+            return SymphonyMessage(
+                id=result.message_id,
+                content=body,
+                created_at=datetime.fromtimestamp(result.timestamp / 1000, tz=timezone.utc),
+                author=SymphonyUser(id=str(self._bot_user_id_int)) if self._bot_user_id_int else None,
+                channel=SymphonyChannel(id=channel_id),
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to upload file: {e}") from e
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
 
     async def edit_message(
         self,

--- a/chatom/telegram/backend.py
+++ b/chatom/telegram/backend.py
@@ -352,6 +352,41 @@ class TelegramBackend(BackendBase):
 
         return result
 
+    async def upload_file(
+        self,
+        channel: Union[str, Channel],
+        data: bytes,
+        filename: str = "file",
+        content_type: str = "",
+        title: str = "",
+        content: str = "",
+        **kwargs: Any,
+    ) -> Message:
+        """Upload a file to a Telegram chat.
+
+        Uses ``send_photo`` for image MIME types and ``send_document``
+        for everything else.
+        """
+        import io
+
+        self._ensure_connected()
+
+        chat_id = await self._resolve_channel_id(channel)
+        buf = io.BytesIO(data)
+        buf.name = filename  # python-telegram-bot reads .name for the filename
+
+        send_kwargs: dict[str, Any] = {"chat_id": int(chat_id)}
+        if content:
+            send_kwargs["caption"] = content
+            send_kwargs["parse_mode"] = "HTML"
+
+        if content_type.startswith("image/"):
+            msg = await self._bot.send_photo(photo=buf, **send_kwargs)
+        else:
+            msg = await self._bot.send_document(document=buf, **send_kwargs)
+
+        return TelegramMessage.from_telegram_message(msg)
+
     async def edit_message(
         self,
         message: Union[str, Message],

--- a/chatom/tests/test_format.py
+++ b/chatom/tests/test_format.py
@@ -2734,3 +2734,207 @@ class TestMessageEmbedRoundTrip:
         assert len(restored.embeds) == 1
         assert restored.embeds[0].title == "RT"
         assert restored.embeds[0].fields[0].name == "K"
+
+
+# -------------------------------------------------------------------------
+# Phase 3: Binary Upload / Enhanced Media Support tests
+# -------------------------------------------------------------------------
+
+
+class TestFormattedAttachmentBinaryData:
+    """Tests for binary data support on FormattedAttachment."""
+
+    def test_has_data_false_by_default(self):
+        att = FormattedAttachment(filename="report.pdf", url="https://example.com/report.pdf")
+        assert att.has_data is False
+        assert att.data is None
+
+    def test_has_data_true_when_set(self):
+        att = FormattedAttachment(filename="report.pdf", data=b"PDF content here")
+        assert att.has_data is True
+        assert att.data == b"PDF content here"
+
+    def test_data_excluded_from_serialization(self):
+        att = FormattedAttachment(filename="f.txt", data=b"hello")
+        d = att.model_dump()
+        assert "data" not in d
+
+    def test_render_still_works_with_data(self):
+        att = FormattedAttachment(filename="f.txt", url="https://x.com/f.txt", data=b"hello")
+        assert "f.txt" in att.render(Format.MARKDOWN)
+
+    def test_render_url_only_when_no_data(self):
+        att = FormattedAttachment(filename="f.txt", url="https://x.com/f.txt")
+        rendered = att.render(Format.SLACK_MARKDOWN)
+        assert "https://x.com/f.txt" in rendered
+
+    def test_empty_bytes_still_has_data(self):
+        att = FormattedAttachment(filename="empty.bin", data=b"")
+        assert att.has_data is True
+
+
+class TestFormattedImageBinaryData:
+    """Tests for binary data support on FormattedImage."""
+
+    def test_has_data_false_by_default(self):
+        img = FormattedImage(url="https://example.com/img.png", alt_text="chart")
+        assert img.has_data is False
+        assert img.data is None
+
+    def test_has_data_true_when_set(self):
+        img = FormattedImage(data=b"\x89PNG\r\n", filename="chart.png", content_type="image/png")
+        assert img.has_data is True
+        assert img.filename == "chart.png"
+        assert img.content_type == "image/png"
+
+    def test_data_excluded_from_serialization(self):
+        img = FormattedImage(url="https://x.com/i.png", data=b"\x89PNG")
+        d = img.model_dump()
+        assert "data" not in d
+
+    def test_render_still_works_with_data(self):
+        img = FormattedImage(url="https://x.com/img.png", data=b"\x89PNG", alt_text="chart")
+        rendered = img.render(Format.MARKDOWN)
+        assert "![chart]" in rendered
+
+    def test_new_fields_filename_content_type(self):
+        img = FormattedImage(
+            filename="plot.jpg",
+            content_type="image/jpeg",
+            alt_text="plot",
+        )
+        assert img.filename == "plot.jpg"
+        assert img.content_type == "image/jpeg"
+
+
+class TestBaseAttachmentBinaryData:
+    """Tests for binary data on the base Attachment model."""
+
+    def test_has_data_false_by_default(self):
+        from chatom.base.attachment import Attachment
+
+        att = Attachment(filename="test.txt")
+        assert att.has_data is False
+        assert att.data is None
+
+    def test_has_data_true_when_set(self):
+        from chatom.base.attachment import Attachment
+
+        att = Attachment(filename="test.txt", data=b"content")
+        assert att.has_data is True
+        assert att.data == b"content"
+
+    def test_data_excluded_from_serialization(self):
+        from chatom.base.attachment import Attachment
+
+        att = Attachment(filename="test.txt", data=b"content")
+        d = att.model_dump()
+        assert "data" not in d
+
+
+class TestBinaryDataRoundTrip:
+    """Tests for binary data through Message <-> FormattedMessage conversion."""
+
+    def test_to_formatted_preserves_data(self):
+        from chatom.base import Message
+        from chatom.base.attachment import Attachment
+
+        att = Attachment(filename="report.pdf", url="", data=b"pdf bytes", content_type="application/pdf")
+        msg = Message(content="Here's the report", attachments=[att], backend="slack")
+        fm = msg.to_formatted()
+        assert len(fm.attachments) == 1
+        assert fm.attachments[0].data == b"pdf bytes"
+        assert fm.attachments[0].has_data is True
+
+    def test_from_formatted_preserves_data(self):
+        from chatom.base import Message
+
+        fm = FormattedMessage()
+        fm.add_text("Report attached")
+        fm.attachments.append(FormattedAttachment(filename="report.pdf", data=b"pdf bytes", content_type="application/pdf"))
+        msg = Message.from_formatted(fm, backend="discord")
+        assert len(msg.attachments) == 1
+        assert msg.attachments[0].data == b"pdf bytes"
+        assert msg.attachments[0].has_data is True
+
+    def test_round_trip_preserves_data(self):
+        from chatom.base import Message
+        from chatom.base.attachment import Attachment
+
+        att = Attachment(filename="img.png", data=b"\x89PNG\r\n", content_type="image/png")
+        original = Message(content="Image", attachments=[att], backend="discord")
+        fm = original.to_formatted()
+        restored = Message.from_formatted(fm, backend="discord")
+        assert restored.attachments[0].data == b"\x89PNG\r\n"
+
+    def test_url_only_attachment_no_data_in_round_trip(self):
+        from chatom.base import Message
+        from chatom.base.attachment import Attachment
+
+        att = Attachment(filename="file.txt", url="https://example.com/file.txt")
+        original = Message(content="Link", attachments=[att], backend="slack")
+        fm = original.to_formatted()
+        restored = Message.from_formatted(fm, backend="slack")
+        assert restored.attachments[0].data is None
+        assert restored.attachments[0].has_data is False
+
+
+class TestFormattedMessageWithBinaryAttachments:
+    """Tests for FormattedMessage methods with binary data."""
+
+    def test_add_image_url_only(self):
+        msg = FormattedMessage()
+        msg.add_image("https://example.com/img.png", alt_text="chart")
+        assert len(msg.content) == 1
+        assert msg.content[0].has_data is False
+
+    def test_content_with_binary_image(self):
+        img = FormattedImage(data=b"\x89PNG", filename="chart.png", content_type="image/png", alt_text="chart")
+        msg = FormattedMessage()
+        msg.content.append(img)
+        assert len(msg.content) == 1
+        assert msg.content[0].has_data is True
+
+    def test_attachment_with_binary_data(self):
+        msg = FormattedMessage()
+        msg.attachments.append(FormattedAttachment(filename="data.csv", data=b"a,b,c\n1,2,3", content_type="text/csv"))
+        assert len(msg.attachments) == 1
+        assert msg.attachments[0].has_data is True
+        assert msg.attachments[0].filename == "data.csv"
+
+
+class TestBackendBaseUploadFile:
+    """Tests for BackendBase.upload_file default behavior."""
+
+    def test_upload_file_raises_not_implemented(self):
+        import pytest
+
+        from chatom.backend import BackendBase
+
+        # Create a minimal concrete subclass
+        class MinimalBackend(BackendBase):
+            name: str = "minimal"
+
+            async def connect(self):
+                pass
+
+            async def disconnect(self):
+                pass
+
+            async def send_message(self, channel, content, **kwargs):
+                return None
+
+            async def fetch_user(self, **kwargs):
+                return None
+
+            async def fetch_channel(self, **kwargs):
+                return None
+
+            async def fetch_messages(self, channel, **kwargs):
+                return []
+
+        import asyncio
+
+        backend = MinimalBackend()
+        with pytest.raises(NotImplementedError):
+            asyncio.get_event_loop().run_until_complete(backend.upload_file("C123", b"data", filename="test.txt"))


### PR DESCRIPTION
3.1 — Binary data support:
- Add data: Optional[bytes] and has_data property to FormattedAttachment, FormattedImage, and base Attachment (excluded from serialization)
- Add filename and content_type fields to FormattedImage
- Preserve binary data through Message <-> FormattedMessage round-trips

3.2 — Per-backend upload methods:
- Add upload_file() to BackendBase (raises NotImplementedError by default)
- Discord: wraps data in discord.File(io.BytesIO(...))
- Slack: uses files_upload_v2 API
- Symphony: writes to temp file, passes to BDK attachment param
- Telegram: send_photo for images, send_document otherwise
- Publish path (_send_messages_thread) separates binary attachments and routes them through upload_file() with graceful fallback

Tests: 22 new tests for binary data, serialization, round-trip, and upload_file default behavior