### PR TITLE
feat: interactive components + interaction streaming

### DIFF
--- a/chatom/__init__.py
+++ b/chatom/__init__.py
@@ -65,6 +65,9 @@ from .base import (
     File,
     Identifiable,
     Image,
+    # Interaction
+    Interaction,
+    InteractionType,
     LookupError,
     # Message
     Message,
@@ -159,6 +162,7 @@ from .format import (
     # Helper functions
     text,
 )
+from .handlers import InteractionHandler, InteractionRegistry
 
 __version__ = "0.1.2"
 
@@ -301,4 +305,9 @@ __all__ = (
     # Bridge
     "IdentityMapper",
     "MessageBridge",
+    # Interactions
+    "Interaction",
+    "InteractionType",
+    "InteractionHandler",
+    "InteractionRegistry",
 )

--- a/chatom/backend/backend.py
+++ b/chatom/backend/backend.py
@@ -28,6 +28,7 @@ from ..base import (
     BaseModel,
     Channel,
     ChannelRegistry,
+    Interaction,
     Message,
     Organization,
     Presence,
@@ -1183,6 +1184,38 @@ class BackendBase(BaseModel):
         raise NotImplementedError("This backend does not support message streaming")
         # This is needed for type checking, but won't be reached
         yield
+
+    async def stream_interactions(
+        self,
+        channel: Optional[Union[str, Channel]] = None,
+    ) -> AsyncIterator[Interaction]:
+        """Stream incoming component interactions in real-time.
+
+        Yields :class:`~chatom.base.Interaction` objects each time a user
+        clicks a button, picks from a select menu, or submits a modal
+        that was sent via this backend.
+
+        Backends that don't natively support interactive components, or
+        where interaction streaming hasn't been implemented yet, should
+        leave this as ``NotImplementedError``.
+
+        Args:
+            channel: Optional channel filter.
+
+        Yields:
+            Interaction: Each component interaction as it arrives.
+
+        Raises:
+            NotImplementedError: If the backend doesn't support
+                interaction streaming.
+
+        Example:
+            >>> async for event in backend.stream_interactions():
+            ...     if event.action_id == "confirm":
+            ...         await handle_confirm(event)
+        """
+        raise NotImplementedError("This backend does not support interaction streaming")
+        yield  # pragma: no cover
 
     async def read_messages(
         self,

--- a/chatom/base/__init__.py
+++ b/chatom/base/__init__.py
@@ -43,6 +43,7 @@ from .conversion import (
     validate_for_backend,
 )
 from .embed import Embed, EmbedAuthor, EmbedField, EmbedFooter, EmbedMedia
+from .interaction import Interaction, InteractionType
 from .mention import (
     ChannelMentionMatch,
     MentionMatch,
@@ -101,6 +102,9 @@ __all__ = (
     "EmbedField",
     "EmbedFooter",
     "EmbedMedia",
+    # Interaction
+    "Interaction",
+    "InteractionType",
     # Reaction
     "Emoji",
     "Reaction",

--- a/chatom/base/interaction.py
+++ b/chatom/base/interaction.py
@@ -1,0 +1,122 @@
+"""Interaction model for chatom.
+
+Represents a user interaction with a message component (button click,
+select menu choice, modal submit, etc.). Platform-agnostic.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from .base import Field, Identifiable
+from .channel import Channel
+from .user import User
+
+__all__ = ("Interaction", "InteractionType")
+
+
+class InteractionType(str, Enum):
+    """The kind of component interaction."""
+
+    BUTTON = "button"
+    """A button click."""
+
+    SELECT = "select"
+    """A select menu selection."""
+
+    MODAL_SUBMIT = "modal_submit"
+    """A modal form submission."""
+
+    OTHER = "other"
+    """Any other interaction (future types)."""
+
+
+class Interaction(Identifiable):
+    """A user interaction with a message component.
+
+    Emitted by backends when a user clicks a button, picks from a select
+    menu, or submits a modal. Handlers can be registered against
+    ``action_id`` via :class:`chatom.handlers.InteractionRegistry` or
+    consumed as a stream via ``backend.stream_interactions()``.
+
+    Attributes:
+        id: Platform-specific interaction ID (e.g. Slack ``action_ts``
+            or Discord interaction snowflake).
+        type: The kind of interaction.
+        action_id: The ``action_id`` declared on the source component.
+            This is the primary dispatch key.
+        values: Selected/submitted values. For buttons this is typically
+            a single-element list with the button's ``value``; for
+            selects it's the picked option values; for modals it's all
+            submitted input values keyed by their ``action_id``.
+        user: The user who triggered the interaction.
+        channel: The channel the source message lives in.
+        message_id: The ID of the message that contained the component.
+        response_token: Opaque, short-lived token some platforms require
+            to reply to the interaction (e.g. Discord interaction token,
+            Slack ``response_url``).
+        created_at: When the interaction happened.
+        raw: The raw event payload from the backend.
+        backend: Name of the backend that produced this interaction.
+        metadata: Additional platform-specific data.
+    """
+
+    type: InteractionType = Field(
+        default=InteractionType.OTHER,
+        description="The kind of component interaction.",
+    )
+    action_id: str = Field(
+        default="",
+        description="Action identifier from the source component.",
+    )
+    values: List[str] = Field(
+        default_factory=list,
+        description="Selected/submitted values.",
+    )
+    user: Optional[User] = Field(
+        default=None,
+        description="The user who triggered the interaction.",
+    )
+    channel: Optional[Channel] = Field(
+        default=None,
+        description="The channel containing the source message.",
+    )
+    message_id: str = Field(
+        default="",
+        description="ID of the message that contained the component.",
+    )
+    response_token: str = Field(
+        default="",
+        description="Short-lived token for replying to this interaction.",
+    )
+    created_at: Optional[datetime] = Field(
+        default=None,
+        description="When the interaction happened.",
+    )
+    raw: Optional[Any] = Field(
+        default=None,
+        description="Raw event payload from the backend.",
+    )
+    backend: str = Field(
+        default="",
+        description="Backend that produced this interaction.",
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional platform-specific data.",
+    )
+
+    @property
+    def value(self) -> str:
+        """Convenience: the first value, or empty string."""
+        return self.values[0] if self.values else ""
+
+    @property
+    def channel_id(self) -> str:
+        """Convenience: the channel ID, or empty string."""
+        return self.channel.id if self.channel else ""
+
+    @property
+    def user_id(self) -> str:
+        """Convenience: the user ID, or empty string."""
+        return self.user.id if self.user else ""

--- a/chatom/base/message.py
+++ b/chatom/base/message.py
@@ -170,6 +170,15 @@ class Message(Identifiable):
         default_factory=list,
         description="Rich embeds in the message.",
     )
+    components: Optional[Any] = Field(
+        default=None,
+        description=(
+            "Interactive UI components attached to the message. "
+            "This is a ``chatom.format.ComponentContainer`` but is typed "
+            "as ``Any`` here to avoid a circular import; use the typed "
+            "accessor ``FormattedMessage.components`` when possible."
+        ),
+    )
     reactions: List[Reaction] = Field(
         default_factory=list,
         description="Reactions on the message.",
@@ -456,6 +465,10 @@ class Message(Identifiable):
         for embed in self.embeds:
             fm.embeds.append(FormattedEmbed(embed=embed))
 
+        # Carry over components
+        if self.components is not None:
+            fm.components = self.components
+
         # Add metadata
         fm.metadata["source_backend"] = self.backend
         fm.metadata["message_id"] = self.id
@@ -526,6 +539,7 @@ class Message(Identifiable):
             backend=backend,
             attachments=attachments,
             embeds=embeds,
+            components=formatted.components,
             metadata=dict(formatted.metadata),
             **kwargs,
         )

--- a/chatom/csp/__init__.py
+++ b/chatom/csp/__init__.py
@@ -30,11 +30,13 @@ except ImportError:
 
 if HAS_CSP:
     from .adapter import BackendAdapter
+    from .interactions import interaction_reader
     from .nodes import message_reader, message_writer
 
     __all__ = (
         "BackendAdapter",
         "HAS_CSP",
+        "interaction_reader",
         "message_reader",
         "message_writer",
     )
@@ -50,5 +52,9 @@ else:
         raise ImportError("csp is not installed. Install with: pip install csp")
 
     def message_writer(*args, **kwargs):
+        """Placeholder when csp is not installed."""
+        raise ImportError("csp is not installed. Install with: pip install csp")
+
+    def interaction_reader(*args, **kwargs):
         """Placeholder when csp is not installed."""
         raise ImportError("csp is not installed. Install with: pip install csp")

--- a/chatom/csp/interactions.py
+++ b/chatom/csp/interactions.py
@@ -1,0 +1,183 @@
+"""CSP push adapter for chatom interaction streams.
+
+This module mirrors ``chatom.csp.nodes.message_reader`` but for
+:class:`~chatom.base.Interaction` events. CSP itself remains optional;
+the public surface in ``chatom.csp.__init__`` guards the import.
+"""
+
+import asyncio
+import contextlib
+import logging
+import threading
+from queue import Queue
+from typing import List, Optional
+
+from csp import ts
+from csp.impl.pushadapter import PushInputAdapter
+from csp.impl.wiring import py_push_adapter_def
+
+from ..backend import BackendBase
+from ..base import Interaction
+
+__all__ = (
+    "InteractionReaderPushAdapter",
+    "interaction_reader",
+)
+
+log = logging.getLogger(__name__)
+
+
+class InteractionReaderPushAdapterImpl(PushInputAdapter):
+    """Read interactions from a chatom backend and push them into CSP."""
+
+    def __init__(
+        self,
+        backend: BackendBase,
+        channel: Optional[str] = None,
+    ):
+        self._backend = backend
+        self._channel = channel
+        self._thread: Optional[threading.Thread] = None
+        self._running_event = threading.Event()
+        self._queue: Queue = Queue()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._error: Optional[Exception] = None
+        self._shutdown_event: Optional[asyncio.Event] = None
+
+    def start(self, starttime, endtime):
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._running_event.set()
+        self._thread.start()
+        # Initial empty tick so CSP doesn't exit before any interaction arrives
+        self.push_tick([])
+
+    def stop(self):
+        if self._running_event.is_set():
+            self._running_event.clear()
+            self._queue.put(None)
+            shutdown_event = self._shutdown_event
+            loop = self._loop
+            if shutdown_event and loop:
+                loop.call_soon_threadsafe(shutdown_event.set)
+            if self._thread:
+                self._thread.join(timeout=2.0)
+        if self._error:
+            raise self._error
+
+    def _run(self):
+        try:
+            asyncio.run(self._async_run_with_setup())
+        except Exception as e:
+            log.exception("Error in interaction reader: %s", e)
+            self._error = e
+            self._running_event.clear()
+        finally:
+            self._queue.put(None)
+
+    async def _async_run_with_setup(self):
+        self._loop = asyncio.get_running_loop()
+        self._shutdown_event = asyncio.Event()
+        try:
+            await self._async_run()
+        finally:
+            self._loop = None
+            self._shutdown_event = None
+
+    async def _async_run(self):
+        # Separate backend instance for this thread's loop, same as message_reader
+        backend_class = type(self._backend)
+        thread_backend = backend_class(config=self._backend.config)
+        await thread_backend.connect()
+
+        drain_task = asyncio.create_task(self._drain())
+        try:
+            try:
+                stream = thread_backend.stream_interactions(channel=self._channel)
+            except NotImplementedError:
+                log.warning(
+                    "Backend %s does not support stream_interactions(); interaction reader will stay idle.",
+                    type(thread_backend).__name__,
+                )
+                await self._shutdown_event.wait()
+                return
+
+            consumer = asyncio.create_task(self._consume(stream))
+            shutdown = asyncio.create_task(self._shutdown_event.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    [consumer, shutdown],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                if not consumer.done():
+                    consumer.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await consumer
+                if not shutdown.done():
+                    shutdown.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await shutdown
+            if consumer.done() and not consumer.cancelled():
+                consumer.result()
+        finally:
+            drain_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await drain_task
+            with contextlib.suppress(Exception):
+                await thread_backend.disconnect()
+
+    async def _consume(self, stream):
+        async for event in stream:
+            if not self._running_event.is_set():
+                break
+            self._queue.put(event)
+
+    async def _drain(self):
+        """Push queued interactions to CSP."""
+        while self._running_event.is_set():
+            try:
+                await asyncio.sleep(0.01)
+                batch: List[Interaction] = []
+                while not self._queue.empty():
+                    item = self._queue.get_nowait()
+                    if item is None:
+                        return
+                    batch.append(item)
+                if batch:
+                    self.push_tick(batch)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                log.exception("Error draining interaction queue")
+
+
+InteractionReaderPushAdapter = py_push_adapter_def(
+    "InteractionReaderPushAdapter",
+    InteractionReaderPushAdapterImpl,
+    ts[List[Interaction]],
+    backend=object,
+    channel=(str, None),
+    memoize=False,
+)
+
+
+def interaction_reader(
+    backend: BackendBase,
+    channel: Optional[str] = None,
+) -> "ts[List[Interaction]]":
+    """Create a CSP time series of interactions from a chatom backend.
+
+    Args:
+        backend: The chatom backend to read from.
+        channel: Optional channel filter.
+
+    Returns:
+        A CSP time series of :class:`~chatom.base.Interaction` lists.
+
+    Example:
+        >>> @csp.graph
+        ... def g():
+        ...     events = interaction_reader(backend)
+        ...     csp.print("interaction", events)
+    """
+    return InteractionReaderPushAdapter(backend=backend, channel=channel)

--- a/chatom/csp/nodes.py
+++ b/chatom/csp/nodes.py
@@ -376,9 +376,17 @@ def _send_messages_thread(msg_queue: Queue, backend: BackendBase):
                         kwargs["attachments"] = url_attachments
                     if msg.embeds:
                         kwargs["embeds"] = msg.embeds
+                    if msg.components is not None and msg.components.rows:
+                        from chatom.format import attach_components_for_backend
+
+                        kwargs["content"] = msg.content
+                        attach_components_for_backend(kwargs, msg.components, thread_backend.get_format())
+                        content_to_send = kwargs.pop("content")
+                    else:
+                        content_to_send = msg.content
                     await thread_backend.send_message(
                         channel=msg.channel_id,
-                        content=msg.content,
+                        content=content_to_send,
                         **kwargs,
                     )
 

--- a/chatom/format/__init__.py
+++ b/chatom/format/__init__.py
@@ -16,6 +16,7 @@ from .components import (
     SelectOption,
     TextInput,
     TextInputStyle,
+    attach_components_for_backend,
 )
 from .embed import FormattedEmbed
 from .message import (
@@ -135,4 +136,5 @@ __all__ = (
     "TextInputStyle",
     "Modal",
     "ComponentContainer",
+    "attach_components_for_backend",
 )

--- a/chatom/format/components.py
+++ b/chatom/format/components.py
@@ -28,6 +28,7 @@ __all__ = (
     "TextInputStyle",
     "Modal",
     "ComponentContainer",
+    "attach_components_for_backend",
 )
 
 
@@ -766,3 +767,39 @@ class ComponentContainer(BaseModel):
         row = self.add_row()
         row.add_select(action_id, options, placeholder)
         return self
+
+
+def attach_components_for_backend(
+    kwargs: Dict[str, Any],
+    container: "ComponentContainer",
+    backend_format: "FORMAT",
+) -> Dict[str, Any]:
+    """Populate ``send_message`` keyword args for interactive components.
+
+    Writes the correct kwarg for the target backend format into ``kwargs``
+    in-place, rendering ``container`` exactly once. Returns ``kwargs`` for
+    chaining.
+
+    - ``SLACK_MARKDOWN``  -> ``blocks`` (Block Kit action blocks)
+    - ``DISCORD_MARKDOWN`` -> ``components`` (Discord component objects)
+    - ``SYMPHONY_MESSAGEML`` -> merged into ``content`` inline
+    - anything else -> ``components`` as a generic fallback
+    """
+    if container is None or not container.rows:
+        return kwargs
+
+    rendered = container.render(backend_format)
+
+    if backend_format == Format.SLACK_MARKDOWN:
+        existing = list(kwargs.get("blocks") or [])
+        kwargs["blocks"] = existing + rendered
+    elif backend_format == Format.DISCORD_MARKDOWN:
+        existing = list(kwargs.get("components") or [])
+        kwargs["components"] = existing + rendered
+    elif backend_format == Format.SYMPHONY_MESSAGEML:
+        inline = "\n".join(r.get("messageml", "") for r in rendered if r)
+        if inline:
+            kwargs["content"] = (kwargs.get("content", "") or "") + "\n" + inline
+    else:
+        kwargs.setdefault("components", rendered)
+    return kwargs

--- a/chatom/handlers.py
+++ b/chatom/handlers.py
@@ -1,0 +1,149 @@
+"""Interaction handler registry.
+
+Provides a small, dependency-free pub/sub for dispatching
+:class:`~chatom.base.Interaction` events to registered callbacks,
+keyed on ``action_id``. Usable with or without CSP.
+
+Example::
+
+    registry = InteractionRegistry()
+
+    @registry.on("confirm_button")
+    async def handle_confirm(event):
+        await backend.send_message(event.channel_id, "Confirmed!")
+
+    # Drive the registry from a backend stream
+    async for event in backend.stream_interactions():
+        await registry.dispatch(event)
+"""
+
+import asyncio
+import inspect
+import logging
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+
+from chatom.base import Interaction
+
+__all__ = ("InteractionHandler", "InteractionRegistry")
+
+log = logging.getLogger(__name__)
+
+#: Handlers can be sync or async callables accepting a single
+#: :class:`Interaction` argument. Async handlers are awaited; sync
+#: handlers are called directly.
+InteractionHandler = Callable[[Interaction], Union[Any, Awaitable[Any]]]
+
+
+class InteractionRegistry:
+    """Dispatch interactions to handlers keyed by ``action_id``.
+
+    Handlers are called in registration order. A single handler can be
+    registered for multiple action IDs by calling :meth:`register`
+    repeatedly. Use ``action_id=""`` (or :meth:`register_default`) to
+    register a catch-all handler that fires when no specific handler
+    matches.
+    """
+
+    WILDCARD = ""
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, List[InteractionHandler]] = {}
+
+    # ----- registration -------------------------------------------------
+
+    def register(self, action_id: str, handler: InteractionHandler) -> None:
+        """Register ``handler`` for ``action_id``."""
+        self._handlers.setdefault(action_id, []).append(handler)
+
+    def register_default(self, handler: InteractionHandler) -> None:
+        """Register a catch-all handler."""
+        self.register(self.WILDCARD, handler)
+
+    def unregister(self, action_id: str, handler: InteractionHandler) -> bool:
+        """Remove a previously registered handler. Returns ``True`` if removed."""
+        handlers = self._handlers.get(action_id)
+        if not handlers:
+            return False
+        try:
+            handlers.remove(handler)
+        except ValueError:
+            return False
+        if not handlers:
+            del self._handlers[action_id]
+        return True
+
+    def clear(self, action_id: Optional[str] = None) -> None:
+        """Remove all handlers, or just those for ``action_id``."""
+        if action_id is None:
+            self._handlers.clear()
+        else:
+            self._handlers.pop(action_id, None)
+
+    def on(self, action_id: str) -> Callable[[InteractionHandler], InteractionHandler]:
+        """Decorator form of :meth:`register`.
+
+        Example::
+
+            @registry.on("my_button")
+            def handle(event): ...
+        """
+
+        def decorator(fn: InteractionHandler) -> InteractionHandler:
+            self.register(action_id, fn)
+            return fn
+
+        return decorator
+
+    # ----- introspection ------------------------------------------------
+
+    @property
+    def action_ids(self) -> List[str]:
+        """Return all registered action IDs (excluding the wildcard)."""
+        return [aid for aid in self._handlers if aid != self.WILDCARD]
+
+    def handlers_for(self, action_id: str) -> List[InteractionHandler]:
+        """Return the handler list that :meth:`dispatch` would call."""
+        specific = self._handlers.get(action_id, [])
+        if specific:
+            return list(specific)
+        return list(self._handlers.get(self.WILDCARD, []))
+
+    # ----- dispatch -----------------------------------------------------
+
+    async def dispatch(self, event: Interaction) -> List[Any]:
+        """Dispatch ``event`` to all matching handlers.
+
+        Returns the list of handler results, in registration order.
+        Exceptions from individual handlers are logged and do not
+        prevent subsequent handlers from running.
+        """
+        results: List[Any] = []
+        for handler in self.handlers_for(event.action_id):
+            try:
+                result = handler(event)
+                if inspect.isawaitable(result):
+                    result = await result
+                results.append(result)
+            except Exception:
+                log.exception(
+                    "Interaction handler for action_id=%r raised",
+                    event.action_id,
+                )
+        return results
+
+    def dispatch_sync(self, event: Interaction) -> List[Any]:
+        """Sync wrapper around :meth:`dispatch`.
+
+        Runs the async dispatcher on the current event loop if one is
+        running, otherwise in a short-lived loop. Useful for CSP nodes
+        and other sync call sites.
+        """
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                # Caller is already inside a running loop; schedule and
+                # block on the result via a dedicated loop.
+                return asyncio.run_coroutine_threadsafe(self.dispatch(event), loop).result()
+        except RuntimeError:
+            pass
+        return asyncio.run(self.dispatch(event))

--- a/chatom/tests/test_interactions.py
+++ b/chatom/tests/test_interactions.py
@@ -1,0 +1,325 @@
+"""Tests for interactive component publishing and interaction handling."""
+
+import asyncio
+from typing import List
+
+import pytest
+
+from chatom import Interaction, InteractionRegistry, InteractionType, Message
+from chatom.format import (
+    ButtonStyle,
+    ComponentContainer,
+    Format,
+    FormattedMessage,
+    SelectOption,
+    attach_components_for_backend,
+)
+
+
+def _run(coro):
+    """Run a coroutine, creating an event loop if needed."""
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                return pool.submit(asyncio.run, coro).result()
+        return loop.run_until_complete(coro)
+    except RuntimeError:
+        return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.1: components on Message + attach_components_for_backend
+# ---------------------------------------------------------------------------
+
+
+class TestMessageComponents:
+    def test_default_components_is_none(self):
+        m = Message(content="hi")
+        assert m.components is None
+
+    def test_attach_component_container(self):
+        m = Message(content="hi")
+        cc = ComponentContainer()
+        cc.add_button("Yes", "go")
+        m.components = cc
+        assert m.components is cc
+        assert len(m.components.rows) == 1
+
+    def test_round_trip_through_formatted(self):
+        fm = FormattedMessage()
+        fm.add_text("click below")
+        fm.components = ComponentContainer()
+        fm.components.add_button("Go", "btn1")
+        msg = Message.from_formatted(fm, backend="slack")
+        assert msg.components is not None
+        assert msg.components.rows[0].components[0].action_id == "btn1"
+
+        fm2 = msg.to_formatted()
+        assert fm2.components is msg.components
+
+    def test_none_components_round_trip(self):
+        fm = FormattedMessage()
+        fm.add_text("plain")
+        msg = Message.from_formatted(fm, backend="slack")
+        assert msg.components is None
+
+
+class TestAttachComponentsForBackend:
+    def _container(self) -> ComponentContainer:
+        c = ComponentContainer()
+        c.add_button("Yes", "yes_btn", style=ButtonStyle.PRIMARY)
+        c.add_button("No", "no_btn", style=ButtonStyle.DANGER)
+        return c
+
+    def test_slack_produces_blocks(self):
+        kw: dict = {}
+        attach_components_for_backend(kw, self._container(), Format.SLACK_MARKDOWN)
+        assert "blocks" in kw
+        # single action row with two buttons
+        assert kw["blocks"][0]["type"] == "actions"
+        assert len(kw["blocks"][0]["elements"]) == 2
+
+    def test_slack_appends_to_existing_blocks(self):
+        kw: dict = {"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "hi"}}]}
+        attach_components_for_backend(kw, self._container(), Format.SLACK_MARKDOWN)
+        assert len(kw["blocks"]) == 2  # original section + our action row
+
+    def test_discord_produces_components(self):
+        kw: dict = {}
+        attach_components_for_backend(kw, self._container(), Format.DISCORD_MARKDOWN)
+        assert "components" in kw
+        assert kw["components"][0]["type"] == 1  # action row
+
+    def test_symphony_inlines_into_content(self):
+        kw: dict = {"content": "please pick"}
+        attach_components_for_backend(kw, self._container(), Format.SYMPHONY_MESSAGEML)
+        assert "components" not in kw
+        assert "blocks" not in kw
+        assert "<button" in kw["content"]
+        assert kw["content"].startswith("please pick")
+
+    def test_empty_container_is_noop(self):
+        kw: dict = {}
+        attach_components_for_backend(kw, ComponentContainer(), Format.SLACK_MARKDOWN)
+        assert kw == {}
+
+    def test_generic_format_uses_components(self):
+        kw: dict = {}
+        attach_components_for_backend(kw, self._container(), Format.MARKDOWN)
+        assert "components" in kw
+
+    def test_select_menu(self):
+        c = ComponentContainer()
+        c.add_select(
+            "picker",
+            [SelectOption(label="A", value="a"), SelectOption(label="B", value="b")],
+        )
+        kw: dict = {}
+        attach_components_for_backend(kw, c, Format.SLACK_MARKDOWN)
+        assert kw["blocks"][0]["elements"][0]["type"] == "static_select"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.2: Interaction model + InteractionRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionModel:
+    def test_defaults(self):
+        i = Interaction(id="x")
+        assert i.type == InteractionType.OTHER
+        assert i.values == []
+        assert i.value == ""
+        assert i.channel_id == ""
+        assert i.user_id == ""
+
+    def test_button_interaction(self):
+        i = Interaction(
+            id="evt1",
+            type=InteractionType.BUTTON,
+            action_id="confirm",
+            values=["ok"],
+            message_id="msg1",
+            backend="slack",
+        )
+        assert i.type == InteractionType.BUTTON
+        assert i.value == "ok"
+        assert i.action_id == "confirm"
+
+    def test_select_interaction(self):
+        i = Interaction(
+            id="evt2",
+            type=InteractionType.SELECT,
+            action_id="picker",
+            values=["opt_a", "opt_b"],
+        )
+        assert i.values == ["opt_a", "opt_b"]
+        assert i.value == "opt_a"
+
+
+class TestInteractionRegistry:
+    def test_register_and_dispatch(self):
+        r = InteractionRegistry()
+        seen: List[str] = []
+
+        def handle(ev: Interaction) -> str:
+            seen.append(ev.value)
+            return ev.value
+
+        r.register("go", handle)
+        results = _run(r.dispatch(Interaction(id="e1", action_id="go", values=["1"])))
+        assert seen == ["1"]
+        assert results == ["1"]
+
+    def test_decorator_registration(self):
+        r = InteractionRegistry()
+
+        @r.on("click")
+        def handle(ev):
+            return "clicked"
+
+        results = _run(r.dispatch(Interaction(id="e", action_id="click")))
+        assert results == ["clicked"]
+
+    def test_async_handler(self):
+        r = InteractionRegistry()
+
+        async def handle(ev):
+            await asyncio.sleep(0)
+            return ev.action_id
+
+        r.register("async_btn", handle)
+        results = _run(r.dispatch(Interaction(id="e", action_id="async_btn")))
+        assert results == ["async_btn"]
+
+    def test_multiple_handlers_run_in_order(self):
+        r = InteractionRegistry()
+        order: List[int] = []
+        r.register("x", lambda e: order.append(1))
+        r.register("x", lambda e: order.append(2))
+        r.register("x", lambda e: order.append(3))
+        _run(r.dispatch(Interaction(id="e", action_id="x")))
+        assert order == [1, 2, 3]
+
+    def test_handler_exception_is_isolated(self):
+        r = InteractionRegistry()
+        results: List[str] = []
+
+        def bad(ev):
+            raise RuntimeError("boom")
+
+        def good(ev):
+            results.append("ran")
+            return "ok"
+
+        r.register("a", bad)
+        r.register("a", good)
+        out = _run(r.dispatch(Interaction(id="e", action_id="a")))
+        assert results == ["ran"]
+        # only the successful handler contributes a result
+        assert out == ["ok"]
+
+    def test_default_handler_for_unmatched(self):
+        r = InteractionRegistry()
+        seen: List[str] = []
+
+        r.register_default(lambda e: seen.append(f"default:{e.action_id}"))
+        r.register("known", lambda e: seen.append("known"))
+
+        _run(r.dispatch(Interaction(id="e1", action_id="known")))
+        _run(r.dispatch(Interaction(id="e2", action_id="surprise")))
+
+        assert seen == ["known", "default:surprise"]
+
+    def test_specific_overrides_default(self):
+        r = InteractionRegistry()
+        calls: List[str] = []
+        r.register_default(lambda e: calls.append("default"))
+        r.register("hit", lambda e: calls.append("specific"))
+        _run(r.dispatch(Interaction(id="e", action_id="hit")))
+        assert calls == ["specific"]
+
+    def test_unregister(self):
+        r = InteractionRegistry()
+
+        def h(ev):
+            return 1
+
+        r.register("a", h)
+        assert r.unregister("a", h) is True
+        assert r.unregister("a", h) is False
+        assert r.action_ids == []
+
+    def test_clear_all(self):
+        r = InteractionRegistry()
+        r.register("a", lambda e: None)
+        r.register("b", lambda e: None)
+        r.clear()
+        assert r.action_ids == []
+
+    def test_clear_one(self):
+        r = InteractionRegistry()
+        r.register("a", lambda e: None)
+        r.register("b", lambda e: None)
+        r.clear("a")
+        assert r.action_ids == ["b"]
+
+    def test_handlers_for(self):
+        r = InteractionRegistry()
+
+        def h1(ev):
+            return 1
+
+        def h2(ev):
+            return 2
+
+        r.register("x", h1)
+        r.register("x", h2)
+        assert r.handlers_for("x") == [h1, h2]
+        # unmatched with no default -> empty list
+        assert r.handlers_for("missing") == []
+
+
+# ---------------------------------------------------------------------------
+# Backend.stream_interactions default behavior
+# ---------------------------------------------------------------------------
+
+
+class TestStreamInteractionsDefault:
+    """The default ``BackendBase.stream_interactions`` raises NotImplementedError."""
+
+    def test_raises_not_implemented(self):
+        from chatom.backend import BackendBase
+
+        class Stub(BackendBase):
+            name = "stub"
+
+            async def connect(self):
+                pass
+
+            async def disconnect(self):
+                pass
+
+            async def send_message(self, channel, content, **kwargs):
+                pass
+
+            async def fetch_user(self, *args, **kwargs):
+                return None
+
+            async def fetch_channel(self, *args, **kwargs):
+                return None
+
+            async def fetch_messages(self, *args, **kwargs):
+                return []
+
+        async def run():
+            stub = Stub()
+            gen = stub.stream_interactions()
+            with pytest.raises(NotImplementedError):
+                async for _ in gen:
+                    pass
+
+        _run(run())


### PR DESCRIPTION
Phase 2.1 — wire interactive components through the publish path:
- Add Message.components (ComponentContainer) with round-trip through FormattedMessage.to_formatted()/from_formatted().
- New chatom.format.attach_components_for_backend() helper that picks the right send_message kwarg per backend (blocks for Slack, components for Discord, inline MessageML for Symphony, generic fallback otherwise).
- csp.nodes._send_messages_thread calls the helper before send_message.

Phase 2.2 — inbound interaction model + handler registry:
- New chatom.base.Interaction / InteractionType model (action_id, values, user, channel, message_id, response_token, raw, backend).
- BackendBase.stream_interactions() async generator (NotImplementedError by default) parallel to stream_messages().
- chatom.handlers.InteractionRegistry: zero-dependency pub/sub keyed on
  action_id wit  action_id wit  action_id wit  action_id wit  action_id wit  action_id wit  action_id wit  action_id wit  action_id wit  action_id wit  actitom  action_id wit  action_id wit  action_id wit  action_id wiP so csp   action_id wit  action_id wit  action_id wit  action_id wit  actionclean.
 