### PR TITLE
feat: unified thread/reply_to kwargs across backends

### DIFF
--- a/chatom/backend/backend.py
+++ b/chatom/backend/backend.py
@@ -874,6 +874,48 @@ class BackendBase(BaseModel):
         """
         return await self.fetch_messages(channel=channel, after=after)
 
+    @staticmethod
+    def _extract_thread_id(thread: Any) -> Optional[str]:
+        """Extract a thread ID from a ``thread=`` kwarg value.
+
+        Accepts ``None``, a ``str`` ID, a :class:`chatom.base.Thread`, or any
+        :class:`chatom.base.Message` (in which case the message's thread ID
+        is used if set, otherwise the message's own ID — matching the
+        "start a thread from this message" idiom).
+
+        Returns the thread ID as a string, or ``None`` if no thread was given.
+        """
+        if thread is None:
+            return None
+        # Local imports to avoid tight coupling in module-scope types
+        from ..base import Message as _Msg
+        from ..base.thread import Thread as _Thread
+
+        if isinstance(thread, str):
+            return thread or None
+        if isinstance(thread, _Thread):
+            return thread.id or None
+        if isinstance(thread, _Msg):
+            return thread.thread_id or thread.id or None
+        # Duck-type fallback
+        return str(getattr(thread, "id", thread)) or None
+
+    @staticmethod
+    def _extract_reply_to_id(reply_to: Any) -> Optional[str]:
+        """Extract a message ID from a ``reply_to=`` kwarg value.
+
+        Accepts ``None``, a ``str`` ID, or a :class:`chatom.base.Message`.
+        """
+        if reply_to is None:
+            return None
+        from ..base import Message as _Msg
+
+        if isinstance(reply_to, str):
+            return reply_to or None
+        if isinstance(reply_to, _Msg):
+            return reply_to.id or None
+        return str(getattr(reply_to, "id", reply_to)) or None
+
     @abstractmethod
     async def send_message(
         self,
@@ -883,11 +925,25 @@ class BackendBase(BaseModel):
     ) -> Message:
         """Send a message to a channel.
 
+        Standardized optional kwargs (recognized by every backend):
+
+        - ``thread``: ``str | Thread | Message | None`` — send into an
+          existing thread. When a ``Message`` is passed, the message's
+          thread is used if set, otherwise the message itself becomes the
+          thread root. Backends translate this to their native concept
+          (Slack ``thread_ts``, Discord thread channel, Telegram
+          ``message_thread_id``). Symphony has no thread concept and
+          silently ignores this.
+        - ``reply_to``: ``str | Message | None`` — reply referencing a
+          specific message (Discord ``reference=``, Telegram
+          ``reply_to_message_id``, Slack ``thread_ts``). Symphony has no
+          native reply and silently ignores this.
+
         Args:
             channel: The channel to send to (ID string or Channel object).
             content: The message content.
             **kwargs: Additional platform-specific options (e.g., embeds,
-                      attachments, thread_id).
+                      attachments, ``thread``, ``reply_to``).
 
         Returns:
             The sent message.
@@ -897,6 +953,9 @@ class BackendBase(BaseModel):
             >>> msg = await backend.send_message("C123", "Hello!")
             >>> msg = await backend.send_message(Channel(id="C123"), "Hello!")
             >>> msg = await backend.send_message(Channel(name="general"), "Hello!")  # Resolves
+            >>> # Thread and reply:
+            >>> msg = await backend.send_message("C123", "In thread", thread=parent_msg)
+            >>> msg = await backend.send_message("C123", "Replying", reply_to=parent_msg)
         """
         raise NotImplementedError("Subclass must implement send_message()")
 

--- a/chatom/base/message.py
+++ b/chatom/base/message.py
@@ -677,6 +677,56 @@ class Message(Identifiable):
             **kwargs,
         )
 
+    async def reply(
+        self,
+        content: str,
+        backend: Any,
+        *,
+        in_thread: bool = True,
+        **kwargs: Any,
+    ) -> "Message":
+        """Reply to this message, threading by default when supported.
+
+        Convenience wrapper around ``backend.send_message`` that removes
+        the per-backend branching needed to "reply in the same thread as
+        the user's message".
+
+        - When ``in_thread`` is True (default), passes ``thread=self`` so
+          the backend posts into this message's thread (starting one if
+          needed, where the platform supports it).
+        - When ``in_thread`` is False, passes ``reply_to=self`` so the
+          backend references this message without forcing a thread.
+
+        Backends that lack the corresponding concept (e.g. Symphony has
+        no threads) silently treat both as a plain top-level send.
+
+        Args:
+            content: The reply content.
+            backend: The backend to send through.
+            in_thread: If True (default), reply in the thread. If False,
+                use a plain reply reference.
+            **kwargs: Additional options forwarded to ``send_message``.
+
+        Returns:
+            The sent reply Message.
+
+        Example:
+            >>> reply = await message.reply("thanks!", backend=slack)
+            >>> reply = await message.reply("ack", backend=slack, in_thread=False)
+        """
+        channel: Any = self.channel if self.channel else self.channel_id
+        if not channel:
+            raise ValueError("Cannot reply: message has no channel information")
+
+        send_kwargs = dict(kwargs)
+        if in_thread:
+            # Prefer existing thread; otherwise this message is the root.
+            send_kwargs["thread"] = self.thread or self
+        else:
+            send_kwargs["reply_to"] = self
+
+        return await backend.send_message(channel=channel, content=content, **send_kwargs)
+
     def as_dm_to_author(self, content: str, **kwargs: Any) -> "Message":
         """Create a new message as a DM to this message's author.
 

--- a/chatom/csp/nodes.py
+++ b/chatom/csp/nodes.py
@@ -376,6 +376,12 @@ def _send_messages_thread(msg_queue: Queue, backend: BackendBase):
                         kwargs["attachments"] = url_attachments
                     if msg.embeds:
                         kwargs["embeds"] = msg.embeds
+                    if msg.thread is not None:
+                        kwargs["thread"] = msg.thread
+                    if msg.reply_to is not None:
+                        kwargs["reply_to"] = msg.reply_to
+                    elif msg.reference is not None and msg.reference.message_id:
+                        kwargs["reply_to"] = msg.reference.message_id
                     if msg.components is not None and msg.components.rows:
                         from chatom.format import attach_components_for_backend
 

--- a/chatom/discord/backend.py
+++ b/chatom/discord/backend.py
@@ -507,7 +507,14 @@ class DiscordBackend(BackendBase):
         Args:
             channel: The channel to send to (ID string or Channel object).
             content: The message content.
-            **kwargs: Additional options (embed, file, tts, etc.).
+            **kwargs: Additional options:
+                - ``thread`` — ``str | Thread | Message``. When set, the
+                  message is sent into the corresponding Discord thread
+                  channel (Discord threads are channels); the ``channel``
+                  arg is ignored for the send itself.
+                - ``reply_to`` — ``str | Message`` translated to
+                  ``discord.MessageReference``.
+                - embed, embeds, file, files, tts.
 
         Returns:
             The sent message.
@@ -515,13 +522,17 @@ class DiscordBackend(BackendBase):
         if self._client is None:
             raise RuntimeError("Not connected to Discord")
 
-        # Resolve channel ID
-        channel_id = await self._resolve_channel_id(channel)
+        # Thread overrides the channel: in Discord a thread IS a channel.
+        thread_id = self._extract_thread_id(kwargs.pop("thread", None))
+        target_channel_id = thread_id if thread_id is not None else await self._resolve_channel_id(channel)
+
+        # reply_to → discord.MessageReference
+        reply_to_id = self._extract_reply_to_id(kwargs.pop("reply_to", None))
 
         try:
-            discord_channel = await self._client.fetch_channel(int(channel_id))
+            discord_channel = await self._client.fetch_channel(int(target_channel_id))
             if discord_channel is None:
-                raise RuntimeError(f"Channel {channel_id} not found")
+                raise RuntimeError(f"Channel {target_channel_id} not found")
 
             # Extract common kwargs
             embed = kwargs.get("embed")
@@ -539,6 +550,11 @@ class DiscordBackend(BackendBase):
                 send_kwargs["file"] = file
             if files:
                 send_kwargs["files"] = files
+            if reply_to_id is not None:
+                send_kwargs["reference"] = discord.MessageReference(
+                    message_id=int(reply_to_id),
+                    channel_id=int(target_channel_id),
+                )
 
             msg = await discord_channel.send(**send_kwargs)
 

--- a/chatom/discord/testing.py
+++ b/chatom/discord/testing.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import PrivateAttr
 
 from ..base import Avatar, Channel, Message, MessageType, Organization, Presence, PresenceStatus, User
+from ..base.thread import Thread
 from .backend import DiscordBackend
 from .channel import DiscordChannel, DiscordChannelType
 from .message import DiscordMessage
@@ -476,6 +477,13 @@ class MockDiscordBackend(DiscordBackend):
         # Resolve channel ID
         channel_id = channel.id if isinstance(channel, Channel) else str(channel)
 
+        # Normalize standardized kwargs (matches production backend)
+        thread_id = self._extract_thread_id(kwargs.pop("thread", None))
+        reply_to_id = self._extract_reply_to_id(kwargs.pop("reply_to", None))
+        # In Discord a thread IS a channel, so route the send there.
+        if thread_id is not None:
+            channel_id = thread_id
+
         # Generate a mock message ID
         existing_count = len(self._sent_messages) + sum(len(msgs) for msgs in self._mock_messages.values())
         message_id = str(1000000000000000000 + existing_count)
@@ -487,7 +495,10 @@ class MockDiscordBackend(DiscordBackend):
             author=DiscordUser(id="bot_user"),
             channel=DiscordChannel(id=channel_id),
             guild=Organization(id=kwargs.get("guild_id", "")) if kwargs.get("guild_id") else None,
+            thread=Thread(id=thread_id) if thread_id else None,
         )
+        if reply_to_id:
+            message.metadata["reply_to_id"] = reply_to_id
         self._sent_messages.append(message)
         return message
 

--- a/chatom/slack/backend.py
+++ b/chatom/slack/backend.py
@@ -529,9 +529,13 @@ class SlackBackend(BackendBase):
         Args:
             channel: The channel to send to (ID string or Channel object).
             content: The message content.
-            **kwargs: Additional options. Accepts both:
-                      - thread_id (chatom standard) - translated to thread_ts
-                      - thread_ts (Slack native)
+            **kwargs: Additional options. Accepts:
+                      - ``thread`` (standardized) - ``str | Thread | Message``,
+                        translated to ``thread_ts``.
+                      - ``reply_to`` (standardized) - ``str | Message``, also
+                        translated to ``thread_ts`` since Slack has no
+                        dedicated reply primitive.
+                      - ``thread_id`` / ``thread_ts`` (legacy) — still honored.
                       Plus: blocks, attachments, unfurl_links, etc.
 
         Returns:
@@ -542,9 +546,18 @@ class SlackBackend(BackendBase):
         # Resolve channel ID
         channel_id = await self._resolve_channel_id(channel)
 
-        # Translate thread_id to thread_ts for Slack API
-        if "thread_id" in kwargs and "thread_ts" not in kwargs:
-            kwargs["thread_ts"] = kwargs.pop("thread_id")
+        # Translate standardized thread/reply_to kwargs to thread_ts
+        if "thread_ts" not in kwargs:
+            thread_ts = self._extract_thread_id(kwargs.pop("thread", None)) or self._extract_reply_to_id(kwargs.pop("reply_to", None))
+            if thread_ts is None and "thread_id" in kwargs:
+                thread_ts = kwargs.pop("thread_id")
+            if thread_ts is not None:
+                kwargs["thread_ts"] = thread_ts
+        else:
+            # thread_ts wins, drop higher-level kwargs
+            kwargs.pop("thread", None)
+            kwargs.pop("reply_to", None)
+            kwargs.pop("thread_id", None)
 
         response = await self._async_client.chat_postMessage(
             channel=channel_id,

--- a/chatom/slack/testing.py
+++ b/chatom/slack/testing.py
@@ -469,6 +469,14 @@ class MockSlackBackend(SlackBackend):
         # Resolve channel ID
         channel_id = channel.id if isinstance(channel, Channel) else str(channel)
 
+        # Translate standardized thread/reply_to kwargs to thread_ts
+        if "thread_ts" not in kwargs:
+            thread_ts = self._extract_thread_id(kwargs.pop("thread", None)) or self._extract_reply_to_id(kwargs.pop("reply_to", None))
+            if thread_ts is None and "thread_id" in kwargs:
+                thread_ts = kwargs.pop("thread_id")
+            if thread_ts is not None:
+                kwargs["thread_ts"] = thread_ts
+
         self._message_counter += 1
         ts = f"{datetime.now().timestamp():.6f}"
 

--- a/chatom/symphony/backend.py
+++ b/chatom/symphony/backend.py
@@ -589,12 +589,23 @@ class SymphonyBackend(BackendBase):
             **kwargs: Additional options:
                 - data: Template data as dict.
                 - attachments: List of attachment file paths.
+                - ``thread`` / ``reply_to`` — Symphony has no thread or
+                  native reply concept, so these are accepted for
+                  cross-backend source compatibility but silently ignored
+                  (logged at debug).
 
         Returns:
             The sent message.
         """
         if self._bdk is None:
             raise RuntimeError("Symphony not connected")
+
+        # Drop standardized thread/reply_to kwargs: Symphony has no
+        # corresponding concept (single timeline, no native reply).
+        thread_val = kwargs.pop("thread", None)
+        reply_val = kwargs.pop("reply_to", None)
+        if thread_val is not None or reply_val is not None:
+            log.debug("Symphony has no thread/reply concept; dropping thread=%r reply_to=%r", thread_val, reply_val)
 
         # Resolve channel ID
         channel_id = await self._resolve_channel_id(channel)

--- a/chatom/symphony/testing.py
+++ b/chatom/symphony/testing.py
@@ -382,6 +382,10 @@ class MockSymphonyBackend(BackendBase):
         # Resolve channel ID
         channel_id = channel.id if isinstance(channel, Channel) else str(channel)
 
+        # Drop standardized thread/reply_to kwargs (Symphony has no concept)
+        kwargs.pop("thread", None)
+        kwargs.pop("reply_to", None)
+
         message_id = str(uuid.uuid4())
         timestamp = datetime.now(timezone.utc)
 

--- a/chatom/telegram/backend.py
+++ b/chatom/telegram/backend.py
@@ -311,8 +311,11 @@ class TelegramBackend(BackendBase):
             channel: The chat to send to (ID string or Channel object).
             content: The message content (HTML formatted).
             **kwargs: Additional options:
-                - thread_id: Reply to a forum topic thread.
-                - reply_to: Message ID to reply to.
+                - thread: ``str | Thread | Message`` — forum topic thread.
+                  Translated to ``message_thread_id``. ``thread_id`` is
+                  still accepted as a legacy alias.
+                - reply_to: ``str | Message`` — message to reply to.
+                  Translated to ``reply_to_message_id``.
                 - parse_mode: Parse mode ('HTML', 'MarkdownV2', or None).
                 - disable_notification: Send silently.
                 - protect_content: Protect message from forwarding.
@@ -330,17 +333,17 @@ class TelegramBackend(BackendBase):
         # Default to HTML parse mode
         send_kwargs["parse_mode"] = kwargs.pop("parse_mode", "HTML")
 
-        # Handle thread_id for forum topics
-        if "thread_id" in kwargs:
-            send_kwargs["message_thread_id"] = int(kwargs.pop("thread_id"))
+        # Handle thread (standardized) / thread_id (legacy) for forum topics
+        thread_val = self._extract_thread_id(kwargs.pop("thread", None))
+        if thread_val is None and "thread_id" in kwargs:
+            thread_val = kwargs.pop("thread_id")
+        if thread_val is not None:
+            send_kwargs["message_thread_id"] = int(thread_val)
 
         # Handle reply_to
-        if "reply_to" in kwargs:
-            reply_to = kwargs.pop("reply_to")
-            if isinstance(reply_to, Message):
-                send_kwargs["reply_to_message_id"] = int(reply_to.id)
-            else:
-                send_kwargs["reply_to_message_id"] = int(reply_to)
+        reply_to_id = self._extract_reply_to_id(kwargs.pop("reply_to", None))
+        if reply_to_id is not None:
+            send_kwargs["reply_to_message_id"] = int(reply_to_id)
 
         # Pass through supported kwargs
         for key in ("disable_notification", "protect_content"):

--- a/chatom/telegram/testing.py
+++ b/chatom/telegram/testing.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import PrivateAttr
 
 from ..base import Channel, Message, MessageType, Presence, PresenceStatus, User
+from ..base.thread import Thread
 from .backend import TelegramBackend
 from .channel import TelegramChannel, TelegramChatType
 from .message import TelegramMessage
@@ -382,6 +383,12 @@ class MockTelegramBackend(TelegramBackend):
         """Send a mock message."""
         channel_id = channel.id if isinstance(channel, Channel) else str(channel)
 
+        # Normalize thread / reply_to (matches production backend)
+        thread_val = self._extract_thread_id(kwargs.pop("thread", None))
+        if thread_val is None and "thread_id" in kwargs:
+            thread_val = kwargs.pop("thread_id")
+        reply_to_id = self._extract_reply_to_id(kwargs.pop("reply_to", None))
+
         self._message_counter += 1
         message_id = str(1000000 + self._message_counter)
 
@@ -393,7 +400,10 @@ class MockTelegramBackend(TelegramBackend):
             created_at=datetime.now(timezone.utc),
             author=TelegramUser(id="bot_user"),
             channel=TelegramChannel(id=channel_id),
+            thread=Thread(id=thread_val) if thread_val else None,
         )
+        if reply_to_id:
+            message.metadata["reply_to_message_id"] = reply_to_id
         self._sent_messages.append(message)
         return message
 

--- a/chatom/tests/test_threads.py
+++ b/chatom/tests/test_threads.py
@@ -1,0 +1,279 @@
+"""Tests for Phase 5: thread abstraction polish.
+
+Covers:
+- BackendBase._extract_thread_id / _extract_reply_to_id helpers.
+- Standardized ``thread=`` / ``reply_to=`` kwargs on each backend's
+  ``send_message`` (via the Mock backends).
+- ``Message.reply()`` convenience helper.
+- ``_send_messages_thread`` forwarding ``msg.thread`` and ``msg.reply_to``
+  as kwargs to ``send_message``.
+"""
+
+import asyncio
+
+import pytest
+from pydantic import SecretStr
+
+from chatom.backend import BackendBase
+from chatom.base import Channel, Message
+from chatom.base.thread import Thread
+
+
+class TestExtractHelpers:
+    def test_extract_thread_id_none(self):
+        assert BackendBase._extract_thread_id(None) is None
+
+    def test_extract_thread_id_empty_string(self):
+        assert BackendBase._extract_thread_id("") is None
+
+    def test_extract_thread_id_string(self):
+        assert BackendBase._extract_thread_id("T1") == "T1"
+
+    def test_extract_thread_id_from_thread(self):
+        assert BackendBase._extract_thread_id(Thread(id="T2")) == "T2"
+
+    def test_extract_thread_id_from_message_with_thread(self):
+        msg = Message(id="M1", thread=Thread(id="T3"))
+        assert BackendBase._extract_thread_id(msg) == "T3"
+
+    def test_extract_thread_id_from_message_without_thread(self):
+        # Root-of-thread idiom: the message itself seeds the thread.
+        msg = Message(id="M2")
+        assert BackendBase._extract_thread_id(msg) == "M2"
+
+    def test_extract_reply_to_id_none(self):
+        assert BackendBase._extract_reply_to_id(None) is None
+
+    def test_extract_reply_to_id_string(self):
+        assert BackendBase._extract_reply_to_id("M1") == "M1"
+
+    def test_extract_reply_to_id_message(self):
+        assert BackendBase._extract_reply_to_id(Message(id="M5")) == "M5"
+
+
+@pytest.fixture
+def slack_backend():
+    from chatom.slack import MockSlackBackend, SlackConfig
+
+    cfg = SlackConfig(bot_token=SecretStr("xoxb-t"), app_token=SecretStr("xapp-t"))
+    return MockSlackBackend(config=cfg)
+
+
+@pytest.fixture
+def discord_backend():
+    from chatom.discord import DiscordConfig, MockDiscordBackend
+
+    cfg = DiscordConfig(bot_token=SecretStr("discord-token"))
+    return MockDiscordBackend(config=cfg)
+
+
+@pytest.fixture
+def telegram_backend():
+    from chatom.telegram import MockTelegramBackend
+
+    return MockTelegramBackend()
+
+
+@pytest.fixture
+def symphony_backend():
+    from chatom.symphony import MockSymphonyBackend, SymphonyConfig
+
+    cfg = SymphonyConfig()
+    return MockSymphonyBackend(config=cfg)
+
+
+class TestSlackThreadKwargs:
+    @pytest.mark.asyncio
+    async def test_thread_message_translated_to_thread_ts(self, slack_backend):
+        await slack_backend.connect()
+        parent = Message(id="1234.5678")
+        msg = await slack_backend.send_message("C1", "hi", thread=parent)
+        assert msg.thread is not None
+        assert msg.thread.id == "1234.5678"
+
+    @pytest.mark.asyncio
+    async def test_thread_string_id(self, slack_backend):
+        await slack_backend.connect()
+        msg = await slack_backend.send_message("C1", "hi", thread="abc.def")
+        assert msg.thread.id == "abc.def"
+
+    @pytest.mark.asyncio
+    async def test_reply_to_uses_thread_ts(self, slack_backend):
+        # Slack has no standalone reply primitive; reply_to collapses to thread_ts.
+        await slack_backend.connect()
+        parent = Message(id="9.9")
+        msg = await slack_backend.send_message("C1", "ack", reply_to=parent)
+        assert msg.thread is not None
+        assert msg.thread.id == "9.9"
+
+    @pytest.mark.asyncio
+    async def test_thread_id_legacy_still_works(self, slack_backend):
+        await slack_backend.connect()
+        msg = await slack_backend.send_message("C1", "hi", thread_id="legacy.123")
+        assert msg.thread.id == "legacy.123"
+
+
+class TestDiscordThreadKwargs:
+    @pytest.mark.asyncio
+    async def test_thread_routes_to_thread_channel(self, discord_backend):
+        await discord_backend.connect()
+        msg = await discord_backend.send_message("CHAN1", "hi", thread="THREAD42")
+        # Discord threads ARE channels, so the message should be sent there.
+        assert msg.channel_id == "THREAD42"
+        assert msg.thread is not None
+        assert msg.thread.id == "THREAD42"
+
+    @pytest.mark.asyncio
+    async def test_reply_to_tracked(self, discord_backend):
+        await discord_backend.connect()
+        parent = Message(id="888")
+        msg = await discord_backend.send_message("CHAN1", "ack", reply_to=parent)
+        assert msg.metadata.get("reply_to_id") == "888"
+
+
+class TestTelegramThreadKwargs:
+    @pytest.mark.asyncio
+    async def test_thread_translated(self, telegram_backend):
+        msg = await telegram_backend.send_message("12345", "hi", thread="777")
+        assert msg.thread is not None
+        assert msg.thread.id == "777"
+
+    @pytest.mark.asyncio
+    async def test_reply_to_tracked(self, telegram_backend):
+        parent = Message(id="42")
+        msg = await telegram_backend.send_message("12345", "ack", reply_to=parent)
+        assert msg.metadata.get("reply_to_message_id") == "42"
+
+
+class TestSymphonyThreadKwargs:
+    @pytest.mark.asyncio
+    async def test_thread_silently_dropped(self, symphony_backend):
+        # Symphony has no thread concept; should accept and ignore rather than raise.
+        await symphony_backend.connect()
+        parent = Message(id="M1")
+        msg = await symphony_backend.send_message("S1", "hi", thread=parent, reply_to=parent)
+        assert msg is not None
+
+
+class TestMessageReply:
+    @pytest.mark.asyncio
+    async def test_reply_in_thread_default(self, slack_backend):
+        await slack_backend.connect()
+        incoming = Message(id="1.0", channel=Channel(id="C1"))
+        reply = await incoming.reply("thanks", backend=slack_backend)
+        # Slack's thread_ts is set from the incoming message id (no existing thread)
+        assert reply.thread is not None
+        assert reply.thread.id == "1.0"
+
+    @pytest.mark.asyncio
+    async def test_reply_preserves_existing_thread(self, slack_backend):
+        await slack_backend.connect()
+        incoming = Message(id="2.0", channel=Channel(id="C1"), thread=Thread(id="root.ts"))
+        reply = await incoming.reply("thanks", backend=slack_backend)
+        assert reply.thread.id == "root.ts"
+
+    @pytest.mark.asyncio
+    async def test_reply_without_thread(self, telegram_backend):
+        incoming = Message(id="99", channel=Channel(id="12345"))
+        reply = await incoming.reply("ack", backend=telegram_backend, in_thread=False)
+        # in_thread=False uses reply_to path
+        assert reply.metadata.get("reply_to_message_id") == "99"
+        assert reply.thread is None
+
+    @pytest.mark.asyncio
+    async def test_reply_without_channel_raises(self, slack_backend):
+        await slack_backend.connect()
+        orphan = Message(id="orphan")
+        with pytest.raises(ValueError, match="no channel"):
+            await orphan.reply("x", backend=slack_backend)
+
+
+class _CapturingBackend(BackendBase):
+    """Captures send_message kwargs for assertion. Uses class-level state
+    so we don't have to plumb config through the CSP writer, which spawns
+    a new backend instance in its own thread."""
+
+    name = "capturing"
+    display_name = "Capturing"
+
+    # class-level capture list so the test sees what the writer thread sent
+    captured: list = []
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+    async def fetch_user(self, identifier=None, **kwargs):
+        return None
+
+    async def fetch_channel(self, identifier=None, **kwargs):
+        return Channel(id=kwargs.get("id") or (identifier or ""))
+
+    async def fetch_messages(self, channel, **kwargs):
+        return []
+
+    async def send_message(self, channel, content, **kwargs):
+        type(self).captured.append({"channel": channel, "content": content, **kwargs})
+        return Message(id="sent", content=content, channel=Channel(id=str(channel)))
+
+
+def test_send_messages_thread_forwards_thread_and_reply_to():
+    """``_send_messages_thread`` must forward ``msg.thread`` and
+    ``msg.reply_to`` as kwargs to ``send_message``."""
+    pytest.importorskip("csp")
+    from queue import Queue
+
+    from chatom.csp.nodes import _send_messages_thread
+
+    _CapturingBackend.captured = []
+    backend = _CapturingBackend()
+
+    parent = Message(id="parent-id")
+    thread_msg = Message(
+        id="m1",
+        content="in thread",
+        channel=Channel(id="C1"),
+        thread=Thread(id="T-root"),
+    )
+    reply_msg = Message(
+        id="m2",
+        content="replying",
+        channel=Channel(id="C1"),
+        reply_to=parent,
+    )
+
+    q: Queue = Queue()
+    q.put(thread_msg)
+    q.put(reply_msg)
+    q.put(None)
+
+    # Run the writer thread function synchronously (it drives its own loop).
+    _send_messages_thread(q, backend)
+
+    captured = _CapturingBackend.captured
+    assert len(captured) == 2
+    assert captured[0]["content"] == "in thread"
+    assert isinstance(captured[0]["thread"], Thread)
+    assert captured[0]["thread"].id == "T-root"
+
+    assert captured[1]["content"] == "replying"
+    # reply_to forwarded as the Message object
+    assert isinstance(captured[1]["reply_to"], Message)
+    assert captured[1]["reply_to"].id == "parent-id"
+
+
+# Make sure asyncio-based tests don't leak loops
+@pytest.fixture(autouse=True)
+def _close_loops():
+    yield
+    # Drain any pending tasks in the default loop policy
+    try:
+        loop = asyncio.get_event_loop_policy().get_event_loop()
+        if not loop.is_closed():
+            pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+            for t in pending:
+                t.cancel()
+    except Exception:
+        pass


### PR DESCRIPTION
Standardize send_message thread kwargs:
- BackendBase gains _extract_thread_id / _extract_reply_to_id helpers accepting str | Thread | Message | None, and documents standardized thread= and reply_to= kwargs on the abstract send_message.
- Each backend translates internally without hardcoded dispatch:
  - Slack: thread / reply_to -> thread_ts (legacy thread_id still honored).
  - Discord: thread -> target thread channel (threads are channels); reply_to -> discord.MessageReference.
  - Telegram: thread -> message_thread_id (forum topics); reply_to -> reply_to_message_id.
  - Symphony: no thread/reply concept — silently drop (logged at debug).
- Mock backends mirror the same translation so tests can assert.

Publish path forwards Message.thread / Message.reply_to:
- csp.nodes._send_messages_thread now forwards msg.thread, msg.reply_to, and msg.reference.message_id (as reply_to fallback) to send_message.

Message.reply(content, backend, *, in_thread=True, **kwargs):
- Convenience helper that uses thread= when in_thread is True (preferring existing thread, else the message itself as root) or reply_to= otherwise. Removes per-backend branching from command implementations.

Tests: new chatom/tests/test_threads.py (23 tests) covers extraction helpers, per-backend kwarg translation, Message.reply, and the publish-path forwarding. Full suite: 1237 passed. Lint clean.
