### PR TITLE
feat: image and document attachment support across backends, agent, and MCP

### DIFF
--- a/chatom/agent/toolset.py
+++ b/chatom/agent/toolset.py
@@ -152,6 +152,72 @@ class AddReactionParams(PydanticBaseModel):
     channel: ChannelRef = Field(description="Channel containing the message.")
 
 
+class ListAttachmentsParams(PydanticBaseModel):
+    """Parameters for listing attachments in a channel's recent history."""
+
+    channel: ChannelRef = Field(description="Channel to scan for attachments. Provide at least channel ID or name.")
+    limit: int = Field(default=20, description="Number of recent messages to scan (1-100).", ge=1, le=100)
+
+
+class DownloadAttachmentParams(PydanticBaseModel):
+    """Parameters for downloading an attachment's content."""
+
+    attachment_id: str = Field(description="ID of the attachment to download (from list_recent_attachments).")
+    channel: ChannelRef = Field(description="Channel the attachment was posted in.")
+    message_id: Optional[str] = Field(
+        default=None,
+        description="ID of the message the attachment belongs to. Required by some backends (e.g. Symphony).",
+    )
+    max_bytes: int = Field(
+        default=5_000_000,
+        description="Maximum number of bytes to return (1-20MB). Larger files are rejected.",
+        ge=1,
+        le=20_000_000,
+    )
+
+
+class UploadFileParams(PydanticBaseModel):
+    """Parameters for uploading a file/image to a channel."""
+
+    channel: ChannelRef = Field(description="Channel to upload the file to.")
+    filename: str = Field(description="Name of the file, including extension (e.g. 'chart.png').")
+    data_base64: str = Field(description="The file content, base64-encoded.")
+    content_type: str = Field(default="", description="MIME type of the file (e.g. 'image/png'). Inferred from filename if omitted.")
+    content: str = Field(default="", description="Optional message text to accompany the file.")
+
+
+class GetBotInfoParams(PydanticBaseModel):
+    """Parameters for retrieving the bot's own profile (none required)."""
+
+
+class GetPresenceParams(PydanticBaseModel):
+    """Parameters for reading a user's presence."""
+
+    user: UserRef = Field(description="User to read presence for. Provide at least one identifier.")
+
+
+class RemoveReactionParams(PydanticBaseModel):
+    """Parameters for removing a reaction."""
+
+    message_id: str = Field(description="ID of the message to remove a reaction from.")
+    emoji: str = Field(description="Emoji name or unicode character to remove.")
+    channel: ChannelRef = Field(description="Channel containing the message.")
+
+
+class DeleteMessageParams(PydanticBaseModel):
+    """Parameters for deleting a message."""
+
+    message_id: str = Field(description="ID of the message to delete.")
+    channel: ChannelRef = Field(description="Channel containing the message.")
+
+
+class SetPresenceParams(PydanticBaseModel):
+    """Parameters for setting the bot's own presence."""
+
+    status: str = Field(description="Presence status (e.g. 'available', 'away', 'busy').")
+    status_text: str = Field(default="", description="Optional custom status text.")
+
+
 _TOOL_DESCRIPTORS: list[dict[str, Any]] = [
     {
         "name": "read_channel_history",
@@ -203,6 +269,24 @@ _TOOL_DESCRIPTORS: list[dict[str, Any]] = [
         "write": False,
     },
     {
+        "name": "get_bot_info",
+        "description": (
+            "Get the bot's own user profile (id, name, handle). Use this for "
+            "self-identification — e.g. to tell whether a message was written by, "
+            "or mentions, the bot itself."
+        ),
+        "params_model": GetBotInfoParams,
+        "capability": None,
+        "write": False,
+    },
+    {
+        "name": "get_presence",
+        "description": "Get a user's presence/status (online, away, busy, etc.).",
+        "params_model": GetPresenceParams,
+        "capability": Capability.PRESENCE,
+        "write": False,
+    },
+    {
         "name": "send_message",
         "description": ("Send a new message to a chat channel. The content should be plain text; formatting is handled automatically."),
         "params_model": SendMessageParams,
@@ -221,6 +305,60 @@ _TOOL_DESCRIPTORS: list[dict[str, Any]] = [
         "description": ("Add an emoji reaction to a message. Use this to acknowledge messages (e.g. '👀' for seen, '✅' for done)."),
         "params_model": AddReactionParams,
         "capability": Capability.EMOJI_REACTIONS,
+        "write": True,
+    },
+    {
+        "name": "remove_reaction",
+        "description": "Remove an emoji reaction that was previously added to a message.",
+        "params_model": RemoveReactionParams,
+        "capability": Capability.EMOJI_REACTIONS,
+        "write": True,
+    },
+    {
+        "name": "delete_message",
+        "description": "Delete a message. This is irreversible; use with care.",
+        "params_model": DeleteMessageParams,
+        "capability": Capability.DELETING,
+        "write": True,
+    },
+    {
+        "name": "set_presence",
+        "description": "Set the bot's own presence/status (e.g. 'available', 'away').",
+        "params_model": SetPresenceParams,
+        "capability": Capability.PRESENCE,
+        "write": True,
+    },
+    {
+        "name": "list_recent_attachments",
+        "description": (
+            "List files, images, and documents attached to recent messages in a channel. "
+            "Returns each attachment's id, filename, content_type, size, and the message_id "
+            "it belongs to. Use this to discover attachments before downloading them."
+        ),
+        "params_model": ListAttachmentsParams,
+        "capability": Capability.FILES,
+        "write": False,
+    },
+    {
+        "name": "download_attachment",
+        "description": (
+            "Download the content of an attachment (image or document) received in chat. "
+            "Returns the bytes base64-encoded along with the filename and content_type. "
+            "Use list_recent_attachments first to find the attachment_id."
+        ),
+        "params_model": DownloadAttachmentParams,
+        "capability": Capability.FILES,
+        "write": False,
+    },
+    {
+        "name": "upload_file",
+        "description": (
+            "Upload a file, image, or document to a channel. Provide the content as "
+            "base64-encoded data plus a filename. Use this to share generated images, "
+            "charts, reports, or documents with the chat."
+        ),
+        "params_model": UploadFileParams,
+        "capability": Capability.FILES,
         "write": True,
     },
 ]
@@ -264,11 +402,13 @@ class BackendToolset(AbstractToolset[Any]):
         read_only: bool = False,
         max_retries: int = 1,
         access_policy: Optional[AccessPolicy] = None,
+        disabled_tools: Optional[set[str]] = None,
     ) -> None:
         self._backend = backend
         self._read_only = read_only
         self._max_retries = max_retries
         self._policy = access_policy or AccessPolicy()
+        self._disabled_tools = disabled_tools or set()
         # Cache for membership checks to avoid repeated API calls
         self._membership_cache: dict[str, bool] = {}
         # Cache for channel resolution to avoid repeated name→ID lookups
@@ -322,6 +462,8 @@ class BackendToolset(AbstractToolset[Any]):
 
     def _should_include(self, desc: dict[str, Any]) -> bool:
         """Decide whether a tool descriptor should be exposed."""
+        if desc["name"] in self._disabled_tools:
+            return False
         if desc["write"] and self._read_only:
             return False
         cap = desc.get("capability")
@@ -593,6 +735,13 @@ class BackendToolset(AbstractToolset[Any]):
         await self._check_channel_access(channel)
         return await self._backend.fetch_channel_members(channel)
 
+    async def _call_get_bot_info(self, args: dict[str, Any]) -> Any:
+        return await self._backend.get_bot_info()
+
+    async def _call_get_presence(self, args: dict[str, Any]) -> Any:
+        user = self._user(args)
+        return await self._backend.get_presence(user.id or user)
+
     async def _call_send_message(self, args: dict[str, Any]) -> Any:
         channel = self._channel(args)
         await self._check_channel_access(channel)
@@ -619,3 +768,140 @@ class BackendToolset(AbstractToolset[Any]):
             channel=channel,
         )
         return {"ok": True}
+
+    async def _call_remove_reaction(self, args: dict[str, Any]) -> Any:
+        channel = self._channel(args)
+        await self._check_channel_access(channel)
+        await self._backend.remove_reaction(
+            message=args["message_id"],
+            emoji=args["emoji"],
+            channel=channel,
+        )
+        return {"ok": True}
+
+    async def _call_delete_message(self, args: dict[str, Any]) -> Any:
+        channel = self._channel(args)
+        await self._check_channel_access(channel)
+        await self._backend.delete_message(
+            message=args["message_id"],
+            channel=channel,
+        )
+        return {"ok": True}
+
+    async def _call_set_presence(self, args: dict[str, Any]) -> Any:
+        await self._backend.set_presence(
+            args["status"],
+            args.get("status_text") or None,
+        )
+        return {"ok": True}
+
+    @staticmethod
+    def _attachment_summary(att: Any, message_id: str = "") -> dict[str, Any]:
+        """Build a compact, JSON-safe summary of an attachment."""
+        return {
+            "attachment_id": getattr(att, "id", "") or "",
+            "filename": getattr(att, "filename", "") or "",
+            "content_type": getattr(att, "content_type", "") or "",
+            "size": getattr(att, "size", None),
+            "attachment_type": getattr(getattr(att, "attachment_type", None), "value", "") or "",
+            "message_id": message_id,
+        }
+
+    async def _call_list_recent_attachments(self, args: dict[str, Any]) -> Any:
+        channel = self._channel(args)
+        channel = await self._resolve_channel_full(channel)
+        await self._check_channel_access(channel)
+        limit = min(args.get("limit", 20), self._policy.max_messages_per_request)
+        messages = await self._backend.fetch_messages(channel=channel, limit=limit)
+        if isinstance(messages, list):
+            messages = self._filter_messages_by_time(messages)
+        result: list[dict[str, Any]] = []
+        for msg in messages or []:
+            msg_id = getattr(msg, "id", "") or ""
+            for att in getattr(msg, "attachments", None) or []:
+                result.append(self._attachment_summary(att, msg_id))
+        return result
+
+    async def _call_download_attachment(self, args: dict[str, Any]) -> Any:
+        import base64
+
+        channel = self._channel(args)
+        channel = await self._resolve_channel_full(channel)
+        await self._check_channel_access(channel)
+
+        attachment_id = args["attachment_id"]
+        message_id = args.get("message_id") or ""
+        max_bytes = args.get("max_bytes", 5_000_000)
+
+        # Locate the attachment within recent history so we get its full
+        # metadata (url / platform IDs) rather than trusting model-supplied
+        # fields. This keeps downloads scoped to the accessible channel.
+        messages = await self._backend.fetch_messages(channel=channel, limit=self._policy.max_messages_per_request)
+        found_att = None
+        found_msg = None
+        for msg in messages or []:
+            if message_id and (getattr(msg, "id", "") or "") != message_id:
+                continue
+            for att in getattr(msg, "attachments", None) or []:
+                if (getattr(att, "id", "") or "") == attachment_id:
+                    found_att = att
+                    found_msg = msg
+                    break
+            if found_att is not None:
+                break
+
+        if found_att is None:
+            return {
+                "error": "not_found",
+                "message": f"No attachment with id '{attachment_id}' found in the recent history of this channel.",
+            }
+
+        if getattr(found_att, "size", None) and found_att.size > max_bytes:
+            return {
+                "error": "too_large",
+                "message": f"Attachment is {found_att.size} bytes which exceeds the {max_bytes}-byte limit.",
+                "size": found_att.size,
+            }
+
+        data = await self._backend.download_attachment(found_att, message=found_msg)
+        if len(data) > max_bytes:
+            return {
+                "error": "too_large",
+                "message": f"Attachment is {len(data)} bytes which exceeds the {max_bytes}-byte limit.",
+                "size": len(data),
+            }
+
+        return {
+            "filename": getattr(found_att, "filename", "") or "",
+            "content_type": getattr(found_att, "content_type", "") or "",
+            "size": len(data),
+            "data_base64": base64.b64encode(data).decode("ascii"),
+        }
+
+    async def _call_upload_file(self, args: dict[str, Any]) -> Any:
+        import base64
+        import binascii
+
+        channel = self._channel(args)
+        channel = await self._resolve_channel_full(channel)
+        await self._check_channel_access(channel)
+
+        try:
+            data = base64.b64decode(args["data_base64"], validate=True)
+        except (binascii.Error, ValueError) as e:
+            return {"error": "invalid_data", "message": f"data_base64 is not valid base64: {e}"}
+
+        content_type = args.get("content_type", "")
+        if not content_type:
+            import mimetypes
+
+            content_type = mimetypes.guess_type(args["filename"])[0] or ""
+
+        sent = await self._backend.upload_file(
+            channel=channel,
+            data=data,
+            filename=args["filename"],
+            content_type=content_type,
+            content=args.get("content", ""),
+        )
+        return {"ok": True, "message_id": getattr(sent, "id", "") or ""}

--- a/chatom/backend/backend.py
+++ b/chatom/backend/backend.py
@@ -24,6 +24,7 @@ from typing import (
 from pydantic import Field
 
 from ..base import (
+    Attachment,
     BackendCapabilities,
     BaseModel,
     Channel,
@@ -1020,6 +1021,80 @@ class BackendBase(BaseModel):
             The sent message.
         """
         raise NotImplementedError("This backend does not support file uploads")
+
+    async def download_attachment(
+        self,
+        attachment: Attachment,
+        *,
+        message: Optional[Message] = None,
+    ) -> bytes:
+        """Download the binary content of an attachment.
+
+        Returns the raw bytes of a file/image/document that was received in
+        chat.  The default implementation returns ``attachment.data`` if it
+        is already populated, otherwise performs an HTTP ``GET`` against
+        ``attachment.url``.
+
+        Backends override this to add platform authentication (Slack
+        ``url_private`` bearer token, Telegram ``getFile``, Symphony
+        attachment API) where a plain public download is not possible.
+
+        Args:
+            attachment: The attachment to download. Must carry either
+                in-memory ``data``, a downloadable ``url``, or a platform
+                file ``id`` (for backends that resolve by ID).
+            message: The message the attachment belongs to. Some backends
+                (e.g. Symphony) require the message and channel context to
+                resolve the download.
+
+        Returns:
+            The raw file bytes.
+
+        Raises:
+            NotImplementedError: If the attachment cannot be resolved to a
+                downloadable source.
+
+        Example:
+            >>> for att in message.attachments:
+            ...     data = await backend.download_attachment(att, message=message)
+            ...     Path(att.filename).write_bytes(data)
+        """
+        if attachment.data is not None:
+            return attachment.data
+        url = (attachment.url or "").strip()
+        if url:
+            return await self._download_url(url)
+        raise NotImplementedError(
+            f"{self.__class__.__name__} cannot download attachment {attachment.id or attachment.filename!r}: no data or url available"
+        )
+
+    async def _download_url(self, url: str, headers: Optional[dict] = None) -> bytes:
+        """Download bytes from an ``http(s)`` URL in a worker thread.
+
+        Only ``http`` and ``https`` schemes are allowed to avoid local-file
+        and other SSRF vectors (e.g. ``file://``).
+
+        Args:
+            url: The URL to download.
+            headers: Optional request headers (e.g. an auth bearer token).
+
+        Returns:
+            The downloaded bytes.
+        """
+        import urllib.request
+        from urllib.parse import urlparse
+
+        scheme = urlparse(url).scheme.lower()
+        if scheme not in ("http", "https"):
+            raise ValueError(f"Refusing to download non-http(s) URL: {url!r}")
+
+        def _get() -> bytes:
+            req = urllib.request.Request(url, headers=headers or {})
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 - scheme validated above
+                return resp.read()
+
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, _get)
 
     async def delete_message(
         self,

--- a/chatom/base/attachment.py
+++ b/chatom/base/attachment.py
@@ -4,7 +4,7 @@ This module provides classes for file attachments and media.
 """
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from .base import BaseModel, Field
 
@@ -81,6 +81,10 @@ class Attachment(BaseModel):
     attachment_type: AttachmentType = Field(
         default=AttachmentType.UNKNOWN,
         description="Type of attachment.",
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Platform-specific data needed to resolve or download the attachment (e.g. Symphony stream/message IDs).",
     )
 
     @property

--- a/chatom/discord/backend.py
+++ b/chatom/discord/backend.py
@@ -15,9 +15,12 @@ from pydantic import Field
 from ..backend import BackendBase
 from ..base import (
     DISCORD_CAPABILITIES,
+    Attachment,
+    AttachmentType,
     Avatar,
     BackendCapabilities,
     Channel,
+    Image,
     Message,
     MessageType,
     Organization,
@@ -37,6 +40,45 @@ from .user import DiscordUser
 __all__ = ("DiscordBackend",)
 
 _log = getLogger(__name__)
+
+
+def _discord_attachments(msg: Any) -> List[Attachment]:
+    """Extract chatom attachments from a discord.py Message.
+
+    Discord attachment URLs are publicly downloadable (signed CDN links),
+    so the base :meth:`BackendBase.download_attachment` works without an
+    override.
+    """
+    attachments: List[Attachment] = []
+    for att in getattr(msg, "attachments", None) or []:
+        content_type = getattr(att, "content_type", "") or ""
+        att_type = Attachment.from_content_type(content_type) if content_type else AttachmentType.FILE
+        if att_type == AttachmentType.IMAGE or content_type.startswith("image/"):
+            attachments.append(
+                Image(
+                    id=str(att.id),
+                    filename=getattr(att, "filename", "") or "",
+                    url=getattr(att, "url", "") or "",
+                    content_type=content_type,
+                    size=getattr(att, "size", None),
+                    width=getattr(att, "width", None),
+                    height=getattr(att, "height", None),
+                    alt_text=getattr(att, "description", "") or "",
+                )
+            )
+        else:
+            attachments.append(
+                Attachment(
+                    id=str(att.id),
+                    filename=getattr(att, "filename", "") or "",
+                    url=getattr(att, "url", "") or "",
+                    content_type=content_type,
+                    size=getattr(att, "size", None),
+                    attachment_type=att_type,
+                )
+            )
+    return attachments
+
 
 # Try to import discord.py
 try:
@@ -421,6 +463,7 @@ class DiscordBackend(BackendBase):
                     channel=DiscordChannel(id=str(msg.channel.id)),
                     guild=Organization(id=str(msg.guild.id)) if msg.guild else None,
                     is_edited=msg.edited_at is not None,
+                    attachments=_discord_attachments(msg),
                 )
                 messages.append(message)
 
@@ -489,6 +532,7 @@ class DiscordBackend(BackendBase):
                     channel=DiscordChannel(id=str(msg.channel.id)),
                     guild=Organization(id=str(msg.guild.id)) if msg.guild else None,
                     is_edited=msg.edited_at is not None,
+                    attachments=_discord_attachments(msg),
                 )
                 messages.append(message)
 
@@ -1446,6 +1490,7 @@ class DiscordBackend(BackendBase):
                     mentions=mention_users,
                     mention_everyone=msg.mention_everyone,
                     mention_roles=[str(r.id) for r in msg.role_mentions] if msg.role_mentions else [],
+                    attachments=_discord_attachments(msg),
                 )
 
                 await message_queue.put(discord_msg)

--- a/chatom/mcp/cli.py
+++ b/chatom/mcp/cli.py
@@ -40,7 +40,14 @@ def main() -> None:
     if not backends:
         raise SystemExit("error: no backends configured — use +gateway=<name>")
 
-    mcp = build_mcp_server(backends, read_only=cfg.server.read_only)
+    enabled = cfg.server.get("enabled_tools") or None
+    disabled = cfg.server.get("disabled_tools") or None
+    mcp = build_mcp_server(
+        backends,
+        read_only=cfg.server.read_only,
+        enabled_tools=set(enabled) if enabled else None,
+        disabled_tools=set(disabled) if disabled else None,
+    )
 
     transport_value: str = cfg.server.transport
     if transport_value not in ("stdio", "http", "sse", "streamable-http"):

--- a/chatom/mcp/config/config.yaml
+++ b/chatom/mcp/config/config.yaml
@@ -7,5 +7,13 @@ server:
   port: 8080
   read_only: false
   auth_token_env: null
+  # Optional allow-list of (unprefixed) tool names. null = expose all tools
+  # (subject to capability and read_only gating).
+  enabled_tools: null
+  # Deny-list of tool names that are never exposed, even when supported.
+  # Destructive / identity-changing tools are off by default.
+  disabled_tools:
+    - delete_message
+    - set_presence
 
 backends: {}

--- a/chatom/mcp/server.py
+++ b/chatom/mcp/server.py
@@ -65,10 +65,24 @@ def _register_backend_tools(
     *,
     prefix: str = "",
     read_only: bool = False,
+    enabled_tools: Optional[set[str]] = None,
+    disabled_tools: Optional[set[str]] = None,
 ) -> None:
-    """Register MCP tools for a single backend."""
+    """Register MCP tools for a single backend.
+
+    Whether a tool is exposed is decided by, in order:
+
+    1. ``read_only`` — write tools are omitted when True.
+    2. The backend's declared capabilities (e.g. ``editing`` for
+       ``edit_message``).
+    3. ``enabled_tools`` — an optional allow-list. When given, only the
+       listed (unprefixed) tool names are registered.
+    4. ``disabled_tools`` — a deny-list that always wins, even over the
+       allow-list and capabilities.
+    """
 
     caps = backend.capabilities
+    disabled = disabled_tools or set()
 
     def _name(base: str) -> str:
         return f"{prefix}__{base}" if prefix else base
@@ -76,7 +90,37 @@ def _register_backend_tools(
     def _has(cap: Capability) -> bool:
         return caps.supports(cap) if caps else True
 
-    @mcp.tool(name=_name("read_channel_history"))
+    def _enabled(base: str) -> bool:
+        if base in disabled:
+            return False
+        if enabled_tools is not None and base not in enabled_tools:
+            return False
+        return True
+
+    def _tool(base: str, *, cap: Optional[Capability] = None, write: bool = False, available: bool = True):
+        """Register the decorated function as an MCP tool when all gates pass.
+
+        The gates are evaluated up-front so disabled tools are never
+        registered with the server (and therefore never advertised).
+        """
+
+        def decorator(fn: Any) -> Any:
+            if write and read_only:
+                return fn
+            if not available:
+                return fn
+            if cap is not None and not _has(cap):
+                return fn
+            if not _enabled(base):
+                return fn
+            mcp.tool(name=_name(base))(fn)
+            return fn
+
+        return decorator
+
+    _attachments_ok = _has(Capability.FILES) or _has(Capability.IMAGES)
+
+    @_tool("read_channel_history")
     async def read_channel_history(
         channel: ChannelRef = Field(description="Channel to read messages from."),
         limit: int = Field(default=50, description="Maximum messages (1-200).", ge=1, le=200),
@@ -85,20 +129,18 @@ def _register_backend_tools(
         msgs = await backend.fetch_messages(channel=channel.to_channel(), limit=limit)
         return _serialize(msgs)
 
-    if _has(Capability.MESSAGE_SEARCH):
+    @_tool("search_messages", cap=Capability.MESSAGE_SEARCH)
+    async def search_messages(
+        query: str = Field(description="Search query string."),
+        channel: Optional[ChannelRef] = Field(default=None, description="Optional channel to limit search to."),
+        limit: int = Field(default=20, description="Maximum results (1-100).", ge=1, le=100),
+    ) -> list[dict[str, Any]]:
+        """Search for messages matching a text query."""
+        ch = channel.to_channel() if channel else None
+        msgs = await backend.search_messages(query=query, channel=ch, limit=limit)
+        return _serialize(msgs)
 
-        @mcp.tool(name=_name("search_messages"))
-        async def search_messages(
-            query: str = Field(description="Search query string."),
-            channel: Optional[ChannelRef] = Field(default=None, description="Optional channel to limit search to."),
-            limit: int = Field(default=20, description="Maximum results (1-100).", ge=1, le=100),
-        ) -> list[dict[str, Any]]:
-            """Search for messages matching a text query."""
-            ch = channel.to_channel() if channel else None
-            msgs = await backend.search_messages(query=query, channel=ch, limit=limit)
-            return _serialize(msgs)
-
-    @mcp.tool(name=_name("lookup_user"))
+    @_tool("lookup_user")
     async def lookup_user(
         user: UserRef = Field(description="User to look up. Provide at least one identifier."),
     ) -> Optional[dict[str, Any]]:
@@ -112,7 +154,7 @@ def _register_backend_tools(
         )
         return _serialize(result)
 
-    @mcp.tool(name=_name("lookup_channel"))
+    @_tool("lookup_channel")
     async def lookup_channel(
         channel: ChannelRef = Field(description="Channel to look up."),
     ) -> Optional[dict[str, Any]]:
@@ -121,7 +163,7 @@ def _register_backend_tools(
         result = await backend.lookup_channel(id=ch.id or None, name=ch.name or None)
         return _serialize(result)
 
-    @mcp.tool(name=_name("get_channel_members"))
+    @_tool("get_channel_members")
     async def get_channel_members(
         channel: ChannelRef = Field(description="Channel to get members for."),
     ) -> list[dict[str, Any]]:
@@ -129,48 +171,187 @@ def _register_backend_tools(
         members = await backend.fetch_channel_members(channel.to_channel())
         return _serialize(members)
 
-    if not read_only:
+    @_tool("get_bot_info")
+    async def get_bot_info() -> Optional[dict[str, Any]]:
+        """Get the bot's own user profile (id, name, handle).
 
-        @mcp.tool(name=_name("send_message"))
-        async def send_message(
-            channel: ChannelRef = Field(description="Channel to send the message to."),
-            content: str = Field(description="Message content to send."),
-        ) -> dict[str, Any]:
-            """Send a message to a channel."""
-            result = await backend.send_message(channel=channel.to_channel(), content=content)
-            return _serialize(result)
+        Useful for self-identification — e.g. checking whether a message
+        was authored by, or mentions, the bot.
+        """
+        return _serialize(await backend.get_bot_info())
 
-        if _has(Capability.EDITING):
+    @_tool("get_presence", cap=Capability.PRESENCE)
+    async def get_presence(
+        user: UserRef = Field(description="User to look up presence for. Provide at least one identifier."),
+    ) -> Optional[dict[str, Any]]:
+        """Get a user's presence/status (online, away, etc.)."""
+        u = user.to_user()
+        return _serialize(await backend.get_presence(u.id or u))
 
-            @mcp.tool(name=_name("edit_message"))
-            async def edit_message(
-                message_id: str = Field(description="ID of the message to edit."),
-                content: str = Field(description="New message content."),
-                channel: ChannelRef = Field(description="Channel containing the message."),
-            ) -> dict[str, Any]:
-                """Edit an existing message."""
-                result = await backend.edit_message(
-                    message=message_id,
-                    content=content,
-                    channel=channel.to_channel(),
+    @_tool("list_recent_attachments", available=_attachments_ok)
+    async def list_recent_attachments(
+        channel: ChannelRef = Field(description="Channel to scan for attachments."),
+        limit: int = Field(default=20, description="Number of recent messages to scan (1-100).", ge=1, le=100),
+    ) -> list[dict[str, Any]]:
+        """List files, images, and documents on recent messages in a channel.
+
+        Returns each attachment's id, filename, content_type, size and the
+        message_id it belongs to. Use this before downloading.
+        """
+        messages = await backend.fetch_messages(channel=channel.to_channel(), limit=limit)
+        result: list[dict[str, Any]] = []
+        for msg in messages or []:
+            msg_id = getattr(msg, "id", "") or ""
+            for att in getattr(msg, "attachments", None) or []:
+                result.append(
+                    {
+                        "attachment_id": getattr(att, "id", "") or "",
+                        "filename": getattr(att, "filename", "") or "",
+                        "content_type": getattr(att, "content_type", "") or "",
+                        "size": getattr(att, "size", None),
+                        "message_id": msg_id,
+                    }
                 )
-                return _serialize(result)
+        return result
 
-        if _has(Capability.EMOJI_REACTIONS):
+    @_tool("download_attachment", available=_attachments_ok)
+    async def download_attachment(
+        attachment_id: str = Field(description="ID of the attachment (from list_recent_attachments)."),
+        channel: ChannelRef = Field(description="Channel the attachment was posted in."),
+        message_id: Optional[str] = Field(default=None, description="Message ID the attachment belongs to (required by some backends)."),
+        max_bytes: int = Field(default=5_000_000, description="Maximum bytes to return (1-20MB).", ge=1, le=20_000_000),
+    ) -> dict[str, Any]:
+        """Download an attachment's content, returned base64-encoded."""
+        import base64
 
-            @mcp.tool(name=_name("add_reaction"))
-            async def add_reaction(
-                message_id: str = Field(description="ID of the message to react to."),
-                emoji: str = Field(description="Emoji name or unicode character."),
-                channel: ChannelRef = Field(description="Channel containing the message."),
-            ) -> dict[str, str]:
-                """Add an emoji reaction to a message."""
-                await backend.add_reaction(
-                    message=message_id,
-                    emoji=emoji,
-                    channel=channel.to_channel(),
-                )
-                return {"ok": "true"}
+        messages = await backend.fetch_messages(channel=channel.to_channel(), limit=100)
+        found_att = None
+        found_msg = None
+        for msg in messages or []:
+            if message_id and (getattr(msg, "id", "") or "") != message_id:
+                continue
+            for att in getattr(msg, "attachments", None) or []:
+                if (getattr(att, "id", "") or "") == attachment_id:
+                    found_att = att
+                    found_msg = msg
+                    break
+            if found_att is not None:
+                break
+
+        if found_att is None:
+            return {"error": "not_found", "message": f"No attachment '{attachment_id}' found in recent history."}
+
+        data = await backend.download_attachment(found_att, message=found_msg)
+        if len(data) > max_bytes:
+            return {"error": "too_large", "message": f"Attachment is {len(data)} bytes (limit {max_bytes}).", "size": len(data)}
+
+        return {
+            "filename": getattr(found_att, "filename", "") or "",
+            "content_type": getattr(found_att, "content_type", "") or "",
+            "size": len(data),
+            "data_base64": base64.b64encode(data).decode("ascii"),
+        }
+
+    @_tool("send_message", write=True)
+    async def send_message(
+        channel: ChannelRef = Field(description="Channel to send the message to."),
+        content: str = Field(description="Message content to send."),
+    ) -> dict[str, Any]:
+        """Send a message to a channel."""
+        result = await backend.send_message(channel=channel.to_channel(), content=content)
+        return _serialize(result)
+
+    @_tool("edit_message", cap=Capability.EDITING, write=True)
+    async def edit_message(
+        message_id: str = Field(description="ID of the message to edit."),
+        content: str = Field(description="New message content."),
+        channel: ChannelRef = Field(description="Channel containing the message."),
+    ) -> dict[str, Any]:
+        """Edit an existing message."""
+        result = await backend.edit_message(
+            message=message_id,
+            content=content,
+            channel=channel.to_channel(),
+        )
+        return _serialize(result)
+
+    @_tool("add_reaction", cap=Capability.EMOJI_REACTIONS, write=True)
+    async def add_reaction(
+        message_id: str = Field(description="ID of the message to react to."),
+        emoji: str = Field(description="Emoji name or unicode character."),
+        channel: ChannelRef = Field(description="Channel containing the message."),
+    ) -> dict[str, str]:
+        """Add an emoji reaction to a message."""
+        await backend.add_reaction(
+            message=message_id,
+            emoji=emoji,
+            channel=channel.to_channel(),
+        )
+        return {"ok": "true"}
+
+    @_tool("remove_reaction", cap=Capability.EMOJI_REACTIONS, write=True)
+    async def remove_reaction(
+        message_id: str = Field(description="ID of the message to remove a reaction from."),
+        emoji: str = Field(description="Emoji name or unicode character to remove."),
+        channel: ChannelRef = Field(description="Channel containing the message."),
+    ) -> dict[str, str]:
+        """Remove an emoji reaction previously added to a message."""
+        await backend.remove_reaction(
+            message=message_id,
+            emoji=emoji,
+            channel=channel.to_channel(),
+        )
+        return {"ok": "true"}
+
+    @_tool("delete_message", cap=Capability.DELETING, write=True)
+    async def delete_message(
+        message_id: str = Field(description="ID of the message to delete."),
+        channel: ChannelRef = Field(description="Channel containing the message."),
+    ) -> dict[str, str]:
+        """Delete a message. Irreversible — disabled by default."""
+        await backend.delete_message(message=message_id, channel=channel.to_channel())
+        return {"ok": "true"}
+
+    @_tool("set_presence", cap=Capability.PRESENCE, write=True)
+    async def set_presence(
+        status: str = Field(description="Presence status (e.g. 'available', 'away', 'busy')."),
+        status_text: str = Field(default="", description="Optional custom status text."),
+    ) -> dict[str, str]:
+        """Set the bot's own presence/status."""
+        await backend.set_presence(status, status_text or None)
+        return {"ok": "true"}
+
+    @_tool("upload_file", write=True, available=_attachments_ok)
+    async def upload_file(
+        channel: ChannelRef = Field(description="Channel to upload the file to."),
+        filename: str = Field(description="Name of the file including extension (e.g. 'chart.png')."),
+        data_base64: str = Field(description="The file content, base64-encoded."),
+        content_type: str = Field(default="", description="MIME type. Inferred from filename if omitted."),
+        content: str = Field(default="", description="Optional accompanying message text."),
+    ) -> dict[str, Any]:
+        """Upload a file, image, or document to a channel."""
+        import base64
+        import binascii
+
+        try:
+            data = base64.b64decode(data_base64, validate=True)
+        except (binascii.Error, ValueError) as e:
+            return {"error": "invalid_data", "message": f"data_base64 is not valid base64: {e}"}
+
+        ct = content_type
+        if not ct:
+            import mimetypes
+
+            ct = mimetypes.guess_type(filename)[0] or ""
+
+        sent = await backend.upload_file(
+            channel=channel.to_channel(),
+            data=data,
+            filename=filename,
+            content_type=ct,
+            content=content,
+        )
+        return {"ok": True, "message_id": getattr(sent, "id", "") or ""}
 
 
 def build_mcp_server(
@@ -178,13 +359,21 @@ def build_mcp_server(
     *,
     name: str = "chatom",
     read_only: bool = False,
+    enabled_tools: Optional[set[str]] = None,
+    disabled_tools: Optional[set[str]] = None,
 ) -> FastMCP:
     """Build a FastMCP server from one or more chatom backends.
 
     Args:
         backends: Map of backend name to instance (e.g. ``{"slack": slack_backend}``).
         name: Server name shown to MCP clients.
-        read_only: If True, omit write tools (send, edit, react).
+        read_only: If True, omit write tools (send, edit, react, etc.).
+        enabled_tools: Optional allow-list of (unprefixed) tool names. When
+            given, only these tools are registered, subject to capability and
+            ``read_only`` gating. ``None`` means "all tools".
+        disabled_tools: Optional deny-list of (unprefixed) tool names that are
+            never registered, even if otherwise available. Useful for omitting
+            destructive tools such as ``delete_message``.
 
     Returns:
         A configured :class:`FastMCP` server ready to run.
@@ -193,5 +382,12 @@ def build_mcp_server(
     single = len(backends) == 1
     for bname, backend in backends.items():
         prefix = "" if single else bname
-        _register_backend_tools(mcp, backend, prefix=prefix, read_only=read_only)
+        _register_backend_tools(
+            mcp,
+            backend,
+            prefix=prefix,
+            read_only=read_only,
+            enabled_tools=enabled_tools,
+            disabled_tools=disabled_tools,
+        )
     return mcp

--- a/chatom/slack/backend.py
+++ b/chatom/slack/backend.py
@@ -11,8 +11,11 @@ from pydantic import Field
 from ..backend import BackendBase
 from ..base import (
     SLACK_CAPABILITIES,
+    Attachment,
+    AttachmentType,
     BackendCapabilities,
     Channel,
+    Image,
     Message,
     MessageType,
     Organization,
@@ -31,6 +34,51 @@ from .user import SlackUser
 __all__ = ("SlackBackend",)
 
 _log = getLogger(__name__)
+
+
+def _slack_attachments(files: List[dict]) -> List[Attachment]:
+    """Convert Slack file objects into chatom attachments.
+
+    Slack file URLs (``url_private``) require an ``Authorization: Bearer``
+    header with the bot token, so :meth:`SlackBackend.download_attachment`
+    overrides the base download to add it.
+    """
+    attachments: List[Attachment] = []
+    for f in files or []:
+        if not isinstance(f, dict):
+            continue
+        mimetype = f.get("mimetype", "") or ""
+        # Prefer the direct-download URL when present.
+        url = f.get("url_private_download") or f.get("url_private") or f.get("permalink") or ""
+        att_type = Attachment.from_content_type(mimetype) if mimetype else AttachmentType.FILE
+        file_id = f.get("id", "") or ""
+        filename = f.get("name", "") or f.get("title", "") or "file"
+        size = f.get("size")
+        if att_type == AttachmentType.IMAGE or mimetype.startswith("image/"):
+            attachments.append(
+                Image(
+                    id=file_id,
+                    filename=filename,
+                    url=url,
+                    content_type=mimetype,
+                    size=size,
+                    width=f.get("original_w"),
+                    height=f.get("original_h"),
+                    thumbnail_url=f.get("thumb_360", "") or "",
+                )
+            )
+        else:
+            attachments.append(
+                Attachment(
+                    id=file_id,
+                    filename=filename,
+                    url=url,
+                    content_type=mimetype,
+                    size=size,
+                    attachment_type=att_type,
+                )
+            )
+    return attachments
 
 
 class SlackBackend(BackendBase):
@@ -395,6 +443,8 @@ class SlackBackend(BackendBase):
             blocks=msg_data.get("blocks", []),
             thread=thread,
             reply_count=msg_data.get("reply_count", 0),
+            files=msg_data.get("files", []) or [],
+            attachments=_slack_attachments(msg_data.get("files", []) or []),
         )
 
     async def fetch_messages(
@@ -613,6 +663,37 @@ class SlackBackend(BackendBase):
             channel=SlackChannel(id=channel_id),
             backend="slack",
         )
+
+    async def download_attachment(
+        self,
+        attachment: Any,
+        *,
+        message: Optional[Message] = None,
+    ) -> bytes:
+        """Download a Slack attachment's bytes.
+
+        Slack ``url_private`` links require the bot token as a bearer
+        token; this override supplies it.  Falls back to ``files.info`` to
+        resolve the private URL when the attachment only carries a file ID.
+        """
+        if attachment.data is not None:
+            return attachment.data
+
+        token = self.config.bot_token_str
+        headers = {"Authorization": f"Bearer {token}"} if token else None
+
+        url = (getattr(attachment, "url", "") or "").strip()
+        if not url and getattr(attachment, "id", ""):
+            self._ensure_connected()
+            info = await self._async_client.files_info(file=attachment.id)
+            if info.get("ok"):
+                f = info.get("file", {})
+                url = f.get("url_private_download") or f.get("url_private") or ""
+
+        if url:
+            return await self._download_url(url, headers=headers)
+
+        return await super().download_attachment(attachment, message=message)
 
     async def edit_message(
         self,
@@ -1208,6 +1289,8 @@ class SlackBackend(BackendBase):
                             thread=Thread(id=thread_ts) if thread_ts else None,
                             created_at=datetime.fromtimestamp(float(ts)) if ts else datetime.now(),
                             mentions=list(mention_users),  # Resolved mention users
+                            files=event.get("files", []) or [],
+                            attachments=_slack_attachments(event.get("files", []) or []),
                             metadata={
                                 "is_im": is_im,
                                 "author_name": author_name,

--- a/chatom/symphony/backend.py
+++ b/chatom/symphony/backend.py
@@ -17,8 +17,11 @@ from pydantic import Field
 from ..backend import BackendBase
 from ..base import (
     SYMPHONY_CAPABILITIES,
+    Attachment,
+    AttachmentType,
     BackendCapabilities,
     Channel,
+    Image,
     Message,
     MessageType,
     Presence,
@@ -80,6 +83,49 @@ PRESENCE_MAP = {
     "off_work": "OFF_WORK",
     "offline": "OFF_WORK",
 }
+
+
+def _symphony_attachments(attachments_info: Any, stream_id: str, message_id: str) -> List[Attachment]:
+    """Convert Symphony ``V4AttachmentInfo`` objects into chatom attachments.
+
+    Symphony has no public download URL; bytes are fetched via the BDK
+    ``get_attachment(stream_id, message_id, attachment_id)`` call.  The
+    stream and message IDs needed for that call are stored in the
+    attachment ``metadata`` so :meth:`SymphonyBackend.download_attachment`
+    can resolve them.
+    """
+    import mimetypes
+
+    result: List[Attachment] = []
+    for info in attachments_info or []:
+        att_id = getattr(info, "id", "") or ""
+        name = getattr(info, "name", "") or "file"
+        size = getattr(info, "size", None)
+        content_type = mimetypes.guess_type(name)[0] or ""
+        att_type = Attachment.from_content_type(content_type) if content_type else AttachmentType.FILE
+        meta = {"stream_id": stream_id, "message_id": message_id}
+        if att_type == AttachmentType.IMAGE or content_type.startswith("image/"):
+            result.append(
+                Image(
+                    id=att_id,
+                    filename=name,
+                    content_type=content_type,
+                    size=size,
+                    metadata=meta,
+                )
+            )
+        else:
+            result.append(
+                Attachment(
+                    id=att_id,
+                    filename=name,
+                    content_type=content_type,
+                    size=size,
+                    attachment_type=att_type,
+                    metadata=meta,
+                )
+            )
+    return result
 
 
 class SymphonyBackend(BackendBase):
@@ -621,6 +667,7 @@ class SymphonyBackend(BackendBase):
                     created_at=datetime.fromtimestamp(msg.timestamp / 1000, tz=timezone.utc),
                     author=SymphonyUser(id=str(msg.user.user_id)) if msg.user else None,
                     channel=SymphonyChannel(id=channel_id),
+                    attachments=_symphony_attachments(getattr(msg, "attachments", None), channel_id, msg.message_id),
                 )
             )
         return messages
@@ -810,6 +857,49 @@ class SymphonyBackend(BackendBase):
         finally:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)
+
+    async def download_attachment(
+        self,
+        attachment: Any,
+        *,
+        message: Optional[Message] = None,
+    ) -> bytes:
+        """Download a Symphony attachment's bytes.
+
+        Symphony attachments have no public URL; they are fetched with the
+        BDK ``get_attachment(stream_id, message_id, attachment_id)`` call,
+        which returns the content base64-encoded.  The required stream and
+        message IDs come from the attachment ``metadata`` (populated when
+        the message was received) or from the supplied ``message``.
+        """
+        import base64
+
+        if attachment.data is not None:
+            return attachment.data
+
+        if self._bdk is None:
+            raise RuntimeError("Symphony not connected")
+
+        meta = getattr(attachment, "metadata", {}) or {}
+        stream_id = meta.get("stream_id") or (message.channel_id if message else "")
+        message_id = meta.get("message_id") or (message.id if message else "")
+        attachment_id = getattr(attachment, "id", "") or ""
+
+        if not (stream_id and message_id and attachment_id):
+            raise NotImplementedError(
+                "Cannot download Symphony attachment: stream_id, message_id and attachment_id are required "
+                "(pass the owning message= or use an attachment received from this backend)."
+            )
+
+        message_service = self._bdk.messages()
+        encoded = await message_service.get_attachment(
+            stream_id=stream_id,
+            message_id=message_id,
+            attachment_id=attachment_id,
+        )
+        if isinstance(encoded, (bytes, bytearray)):
+            return base64.b64decode(encoded)
+        return base64.b64decode(str(encoded))
 
     async def edit_message(
         self,
@@ -1476,6 +1566,7 @@ class SymphonyBackend(BackendBase):
                     created_at=msg_timestamp,
                     data=msg.data,
                     mentions=list(mention_users),  # List of SymphonyUser objects
+                    attachments=_symphony_attachments(getattr(msg, "attachments", None), stream_id, msg.message_id),
                 )
 
                 # If we didn't find the author via lookup, use info from initiator

--- a/chatom/telegram/backend.py
+++ b/chatom/telegram/backend.py
@@ -390,6 +390,30 @@ class TelegramBackend(BackendBase):
 
         return TelegramMessage.from_telegram_message(msg)
 
+    async def download_attachment(
+        self,
+        attachment: Any,
+        *,
+        message: Optional[Message] = None,
+    ) -> bytes:
+        """Download an attachment's bytes from Telegram.
+
+        Telegram media is referenced by ``file_id`` (stored as the
+        attachment ``id``), which is resolved to a temporary download via
+        ``getFile``.
+        """
+        if attachment.data is not None:
+            return attachment.data
+
+        file_id = (getattr(attachment, "id", "") or "").strip()
+        if file_id:
+            self._ensure_connected()
+            tg_file = await self._bot.get_file(file_id)
+            data = await tg_file.download_as_bytearray()
+            return bytes(data)
+
+        return await super().download_attachment(attachment, message=message)
+
     async def edit_message(
         self,
         message: Union[str, Message],

--- a/chatom/telegram/message.py
+++ b/chatom/telegram/message.py
@@ -5,7 +5,7 @@ This module provides the Telegram-specific Message class.
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from chatom.base import Field, Message, User
+from chatom.base import Attachment, AttachmentType, Field, Image, Message, User
 from chatom.telegram.channel import TelegramChannel
 from chatom.telegram.user import TelegramUser
 
@@ -13,6 +13,85 @@ if TYPE_CHECKING:
     from chatom.format import FormattedMessage
 
 __all__ = ("TelegramMessage",)
+
+
+def _telegram_attachments(msg: Any) -> List[Attachment]:
+    """Extract chatom attachments from a python-telegram-bot Message.
+
+    Telegram does not expose download URLs directly — each media object
+    carries a ``file_id`` that must be resolved via ``getFile``.  The
+    ``file_id`` is stored as the attachment ``id`` so
+    :meth:`TelegramBackend.download_attachment` can fetch the bytes.
+    """
+    attachments: List[Attachment] = []
+
+    photos = getattr(msg, "photo", None)
+    if photos:
+        largest = photos[-1]  # Telegram orders photo sizes smallest-to-largest
+        attachments.append(
+            Image(
+                id=largest.file_id,
+                filename="photo.jpg",
+                content_type="image/jpeg",
+                size=getattr(largest, "file_size", None),
+                width=getattr(largest, "width", None),
+                height=getattr(largest, "height", None),
+            )
+        )
+
+    document = getattr(msg, "document", None)
+    if document is not None:
+        content_type = getattr(document, "mime_type", "") or ""
+        attachments.append(
+            Attachment(
+                id=document.file_id,
+                filename=getattr(document, "file_name", "") or "file",
+                content_type=content_type,
+                size=getattr(document, "file_size", None),
+                attachment_type=(Attachment.from_content_type(content_type) if content_type else AttachmentType.FILE),
+            )
+        )
+
+    video = getattr(msg, "video", None)
+    if video is not None:
+        content_type = getattr(video, "mime_type", "") or "video/mp4"
+        attachments.append(
+            Attachment(
+                id=video.file_id,
+                filename=getattr(video, "file_name", "") or "video.mp4",
+                content_type=content_type,
+                size=getattr(video, "file_size", None),
+                attachment_type=AttachmentType.VIDEO,
+            )
+        )
+
+    audio = getattr(msg, "audio", None)
+    if audio is not None:
+        content_type = getattr(audio, "mime_type", "") or "audio/mpeg"
+        attachments.append(
+            Attachment(
+                id=audio.file_id,
+                filename=getattr(audio, "file_name", "") or "audio",
+                content_type=content_type,
+                size=getattr(audio, "file_size", None),
+                attachment_type=AttachmentType.AUDIO,
+            )
+        )
+
+    voice = getattr(msg, "voice", None)
+    if voice is not None:
+        content_type = getattr(voice, "mime_type", "") or "audio/ogg"
+        attachments.append(
+            Attachment(
+                id=voice.file_id,
+                filename="voice.ogg",
+                content_type=content_type,
+                size=getattr(voice, "file_size", None),
+                attachment_type=AttachmentType.AUDIO,
+            )
+        )
+
+    return attachments
 
 
 class TelegramMessage(Message):
@@ -226,6 +305,7 @@ class TelegramMessage(Message):
             entities=[{"type": e.type, "offset": e.offset, "length": e.length} for e in (msg.entities or [])],
             has_protected_content=getattr(msg, "has_protected_content", False) or False,
             mentions=mention_users,
+            attachments=_telegram_attachments(msg),
             backend="telegram",
         )
 

--- a/chatom/tests/test_agent.py
+++ b/chatom/tests/test_agent.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 import pytest
 
 from chatom.backend import BackendBase
-from chatom.base import Channel, Message, User
+from chatom.base import Channel, Image, Message, User
 from chatom.base.capabilities import (
     SLACK_CAPABILITIES,
     BackendCapabilities,
@@ -31,6 +31,10 @@ class _MockBackend(BackendBase):
     sent: list = []
     edited: list = []
     reactions: list = []
+    uploaded: list = []
+    removed_reactions: list = []
+    deleted: list = []
+    presence_set: list = []
 
     def _configure(
         self,
@@ -49,6 +53,10 @@ class _MockBackend(BackendBase):
         self.sent = []
         self.edited = []
         self.reactions = []
+        self.uploaded = []
+        self.removed_reactions = []
+        self.deleted = []
+        self.presence_set = []
         return self
 
     async def connect(self) -> None:
@@ -160,6 +168,63 @@ class _MockBackend(BackendBase):
         ch_id = channel if isinstance(channel, str) else (channel.id if channel else "")
         self.reactions.append({"message_id": msg_id, "emoji": emoji, "channel": ch_id})
 
+    async def upload_file(
+        self,
+        channel: Union[str, Channel],
+        data: bytes,
+        filename: str = "file",
+        content_type: str = "",
+        title: str = "",
+        content: str = "",
+        **kwargs: Any,
+    ) -> Message:
+        ch_id = channel if isinstance(channel, str) else channel.id
+        self.uploaded.append(
+            {
+                "channel": ch_id,
+                "data": data,
+                "filename": filename,
+                "content_type": content_type,
+                "content": content,
+            }
+        )
+        return Message(id="uploaded_1", content=content, channel=Channel(id=ch_id))
+
+    async def download_attachment(self, attachment: Any, *, message: Optional[Message] = None) -> bytes:
+        if attachment.data is not None:
+            return attachment.data
+        # Return deterministic bytes keyed off the attachment id for tests.
+        return f"bytes:{getattr(attachment, 'id', '')}".encode()
+
+    async def get_bot_info(self) -> Optional[User]:
+        return User(id="BOT1", name="Test Bot", handle="testbot")
+
+    async def get_presence(self, user: Union[str, User]) -> Any:
+        uid = user if isinstance(user, str) else user.id
+        return {"user_id": uid, "status": "available"}
+
+    async def remove_reaction(
+        self,
+        message: Union[str, Message],
+        emoji: str,
+        channel: Optional[Union[str, Channel]] = None,
+    ) -> None:
+        msg_id = message if isinstance(message, str) else message.id
+        ch_id = channel if isinstance(channel, str) else (channel.id if channel else "")
+        self.removed_reactions.append({"message_id": msg_id, "emoji": emoji, "channel": ch_id})
+
+    async def delete_message(
+        self,
+        message: Union[str, Message],
+        channel: Optional[Union[str, Channel]] = None,
+    ) -> None:
+        msg_id = message if isinstance(message, str) else message.id
+        ch_id = channel if isinstance(channel, str) else (channel.id if channel else "")
+        self.deleted.append({"message_id": msg_id, "channel": ch_id})
+
+    async def set_presence(self, status: str, status_text: Optional[str] = None, **kwargs: Any) -> None:
+        self.presence_set.append({"status": status, "status_text": status_text})
+
 
 @pytest.fixture
 def alice() -> User:
@@ -226,9 +291,17 @@ class TestBackendToolset:
             "lookup_user",
             "lookup_channel",
             "get_channel_members",
+            "get_bot_info",
+            "get_presence",
             "send_message",
             "edit_message",
             "add_reaction",
+            "remove_reaction",
+            "delete_message",
+            "set_presence",
+            "list_recent_attachments",
+            "download_attachment",
+            "upload_file",
         }
         assert set(tools.keys()) == expected_names
 
@@ -243,10 +316,32 @@ class TestBackendToolset:
         ctx.retries = {}
         tools = await toolset.get_tools(ctx)
 
-        write_tools = {"send_message", "edit_message", "add_reaction"}
+        write_tools = {"send_message", "edit_message", "add_reaction", "remove_reaction", "delete_message", "set_presence", "upload_file"}
         assert write_tools.isdisjoint(set(tools.keys()))
         assert "read_channel_history" in tools
         assert "lookup_user" in tools
+        # Read-side tools remain available in read-only mode.
+        assert "list_recent_attachments" in tools
+        assert "download_attachment" in tools
+        assert "get_bot_info" in tools
+        assert "get_presence" in tools
+
+    @pytest.mark.asyncio
+    async def test_disabled_tools_are_omitted(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend, disabled_tools={"delete_message", "set_presence"})
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        ctx.retries = {}
+        tools = await toolset.get_tools(ctx)
+
+        assert "delete_message" not in tools
+        assert "set_presence" not in tools
+        # Non-disabled tools remain.
+        assert "remove_reaction" in tools
+        assert "get_bot_info" in tools
 
     @pytest.mark.asyncio
     async def test_capability_gating(self) -> None:
@@ -269,6 +364,10 @@ class TestBackendToolset:
         assert "add_reaction" not in tools
         assert "read_channel_history" in tools
         assert "lookup_user" in tools
+        # No FILES capability → attachment tools are gated off.
+        assert "list_recent_attachments" not in tools
+        assert "download_attachment" not in tools
+        assert "upload_file" not in tools
 
     @pytest.mark.asyncio
     async def test_id_property(self, mock_backend: _MockBackend) -> None:
@@ -365,6 +464,190 @@ class TestBackendToolset:
         )
         assert result == {"ok": True}
         assert mock_backend.reactions[0]["emoji"] == "thumbsup"
+
+    @pytest.mark.asyncio
+    async def test_call_get_bot_info(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool("get_bot_info", {}, ctx, tool)
+        assert result["id"] == "BOT1"
+        assert result["handle"] == "testbot"
+
+    @pytest.mark.asyncio
+    async def test_call_get_presence(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool("get_presence", {"user": {"id": "U1"}}, ctx, tool)
+        assert result["status"] == "available"
+        assert result["user_id"] == "U1"
+
+    @pytest.mark.asyncio
+    async def test_call_remove_reaction(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool(
+            "remove_reaction",
+            {"message_id": "m1", "emoji": "thumbsup", "channel": {"id": "C1"}},
+            ctx,
+            tool,
+        )
+        assert result == {"ok": True}
+        assert mock_backend.removed_reactions[0]["emoji"] == "thumbsup"
+
+    @pytest.mark.asyncio
+    async def test_call_delete_message(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool(
+            "delete_message",
+            {"message_id": "m1", "channel": {"id": "C1"}},
+            ctx,
+            tool,
+        )
+        assert result == {"ok": True}
+        assert mock_backend.deleted[0]["message_id"] == "m1"
+
+    @pytest.mark.asyncio
+    async def test_call_set_presence(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool(
+            "set_presence",
+            {"status": "away", "status_text": "lunch"},
+            ctx,
+            tool,
+        )
+        assert result == {"ok": True}
+        assert mock_backend.presence_set[0] == {"status": "away", "status_text": "lunch"}
+
+    @pytest.mark.asyncio
+    async def test_call_list_recent_attachments(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        # Attach an image to one of the channel's messages.
+        msgs = mock_backend._messages["C1"]
+        msgs[0].attachments = [Image(id="att1", filename="pic.png", content_type="image/png", size=123)]
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool(
+            "list_recent_attachments",
+            {"channel": {"id": "C1"}, "limit": 50},
+            ctx,
+            tool,
+        )
+        assert isinstance(result, list)
+        assert any(a["attachment_id"] == "att1" and a["filename"] == "pic.png" for a in result)
+        assert result[0]["message_id"] == msgs[0].id
+
+    @pytest.mark.asyncio
+    async def test_call_download_attachment(self, mock_backend: _MockBackend) -> None:
+        import base64
+
+        from chatom.agent.toolset import BackendToolset
+
+        msgs = mock_backend._messages["C1"]
+        msgs[0].attachments = [Image(id="att1", filename="pic.png", content_type="image/png")]
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool(
+            "download_attachment",
+            {"attachment_id": "att1", "channel": {"id": "C1"}},
+            ctx,
+            tool,
+        )
+        assert result["filename"] == "pic.png"
+        assert base64.b64decode(result["data_base64"]) == b"bytes:att1"
+
+    @pytest.mark.asyncio
+    async def test_call_download_attachment_not_found(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool(
+            "download_attachment",
+            {"attachment_id": "missing", "channel": {"id": "C1"}},
+            ctx,
+            tool,
+        )
+        assert result["error"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_call_upload_file(self, mock_backend: _MockBackend) -> None:
+        import base64
+
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        payload = base64.b64encode(b"PNGDATA").decode("ascii")
+        result = await toolset.call_tool(
+            "upload_file",
+            {"channel": {"id": "C1"}, "filename": "out.png", "data_base64": payload},
+            ctx,
+            tool,
+        )
+        assert result["ok"] is True
+        assert mock_backend.uploaded[0]["data"] == b"PNGDATA"
+        assert mock_backend.uploaded[0]["filename"] == "out.png"
+        # content_type inferred from filename
+        assert mock_backend.uploaded[0]["content_type"] == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_call_upload_file_invalid_base64(self, mock_backend: _MockBackend) -> None:
+        from chatom.agent.toolset import BackendToolset
+
+        toolset = BackendToolset(mock_backend)
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        tool = MagicMock()
+        result = await toolset.call_tool(
+            "upload_file",
+            {"channel": {"id": "C1"}, "filename": "out.png", "data_base64": "not!base64!"},
+            ctx,
+            tool,
+        )
+        assert result["error"] == "invalid_data"
 
     @pytest.mark.asyncio
     async def test_call_unknown_tool_raises(self, mock_backend: _MockBackend) -> None:

--- a/chatom/tests/test_format.py
+++ b/chatom/tests/test_format.py
@@ -2933,3 +2933,68 @@ class TestBackendBaseUploadFile:
         backend = MinimalBackend()
         with pytest.raises(NotImplementedError):
             asyncio.run(backend.upload_file("C123", b"data", filename="test.txt"))
+
+
+class TestBackendBaseDownloadAttachment:
+    """Tests for BackendBase.download_attachment default behavior."""
+
+    @staticmethod
+    def _backend():
+        from chatom.backend import BackendBase
+
+        class MinimalBackend(BackendBase):
+            name: str = "minimal-dl"
+
+            async def connect(self):
+                pass
+
+            async def disconnect(self):
+                pass
+
+            async def send_message(self, channel, content, **kwargs):
+                return None
+
+            async def fetch_user(self, **kwargs):
+                return None
+
+            async def fetch_channel(self, **kwargs):
+                return None
+
+            async def fetch_messages(self, channel, **kwargs):
+                return []
+
+        return MinimalBackend()
+
+    def test_returns_inline_data(self):
+        import asyncio
+
+        from chatom.base import Attachment
+
+        backend = self._backend()
+        att = Attachment(id="a", filename="f.bin", data=b"hello")
+        assert asyncio.run(backend.download_attachment(att)) == b"hello"
+
+    def test_no_source_raises_not_implemented(self):
+        import asyncio
+
+        import pytest
+
+        from chatom.base import Attachment
+
+        backend = self._backend()
+        att = Attachment(id="a", filename="f.bin")  # no data, no url
+        with pytest.raises(NotImplementedError):
+            asyncio.run(backend.download_attachment(att))
+
+    def test_non_http_url_rejected(self):
+        """The base downloader must refuse non-http(s) URLs (SSRF guard)."""
+        import asyncio
+
+        import pytest
+
+        from chatom.base import Attachment
+
+        backend = self._backend()
+        att = Attachment(id="a", filename="passwd", url="file:///etc/passwd")
+        with pytest.raises(ValueError, match="non-http"):
+            asyncio.run(backend.download_attachment(att))

--- a/chatom/tests/test_incoming_attachments.py
+++ b/chatom/tests/test_incoming_attachments.py
@@ -1,0 +1,164 @@
+"""Tests for extracting incoming attachments into chatom Message.attachments.
+
+Each backend converts platform-specific media on received messages into
+chatom :class:`~chatom.base.Attachment` / :class:`~chatom.base.Image`
+objects. These tests exercise the pure extraction helpers with lightweight
+fakes so no platform SDK or network is required.
+"""
+
+from types import SimpleNamespace
+
+from chatom.base import AttachmentType
+
+
+class TestSlackIncomingAttachments:
+    def test_image_and_document(self):
+        from chatom.slack.backend import _slack_attachments
+
+        files = [
+            {
+                "id": "F1",
+                "name": "chart.png",
+                "mimetype": "image/png",
+                "size": 2048,
+                "url_private": "https://files.slack.com/chart.png",
+                "original_w": 800,
+                "original_h": 600,
+            },
+            {
+                "id": "F2",
+                "name": "report.pdf",
+                "mimetype": "application/pdf",
+                "size": 9000,
+                "url_private_download": "https://files.slack.com/report.pdf",
+            },
+        ]
+        atts = _slack_attachments(files)
+        assert len(atts) == 2
+        img = atts[0]
+        assert img.attachment_type == AttachmentType.IMAGE
+        assert img.id == "F1"
+        assert img.url == "https://files.slack.com/chart.png"
+        assert img.width == 800 and img.height == 600
+        doc = atts[1]
+        assert doc.attachment_type == AttachmentType.DOCUMENT
+        # prefers url_private_download
+        assert doc.url == "https://files.slack.com/report.pdf"
+
+    def test_empty(self):
+        from chatom.slack.backend import _slack_attachments
+
+        assert _slack_attachments([]) == []
+        assert _slack_attachments(None) == []
+
+
+class TestDiscordIncomingAttachments:
+    def test_image_and_file(self):
+        from chatom.discord.backend import _discord_attachments
+
+        msg = SimpleNamespace(
+            attachments=[
+                SimpleNamespace(
+                    id=111,
+                    filename="pic.jpg",
+                    url="https://cdn.discord/pic.jpg",
+                    content_type="image/jpeg",
+                    size=1234,
+                    width=640,
+                    height=480,
+                    description="a pic",
+                ),
+                SimpleNamespace(
+                    id=222,
+                    filename="data.csv",
+                    url="https://cdn.discord/data.csv",
+                    content_type="text/csv",
+                    size=55,
+                ),
+            ]
+        )
+        atts = _discord_attachments(msg)
+        assert len(atts) == 2
+        assert atts[0].attachment_type == AttachmentType.IMAGE
+        assert atts[0].id == "111"
+        assert atts[0].url == "https://cdn.discord/pic.jpg"
+        assert atts[0].alt_text == "a pic"
+        # text/* maps to CODE per from_content_type
+        assert atts[1].id == "222"
+        assert atts[1].url == "https://cdn.discord/data.csv"
+
+    def test_no_attachments(self):
+        from chatom.discord.backend import _discord_attachments
+
+        assert _discord_attachments(SimpleNamespace(attachments=[])) == []
+        assert _discord_attachments(SimpleNamespace()) == []
+
+
+class TestTelegramIncomingAttachments:
+    def test_photo_largest_selected(self):
+        from chatom.telegram.message import _telegram_attachments
+
+        msg = SimpleNamespace(
+            photo=[
+                SimpleNamespace(file_id="small", width=90, height=90, file_size=100),
+                SimpleNamespace(file_id="big", width=1280, height=1280, file_size=5000),
+            ],
+            document=None,
+            video=None,
+            audio=None,
+            voice=None,
+        )
+        atts = _telegram_attachments(msg)
+        assert len(atts) == 1
+        assert atts[0].attachment_type == AttachmentType.IMAGE
+        # Telegram has no URL — the file_id is stored as the id for getFile.
+        assert atts[0].id == "big"
+        assert atts[0].url == ""
+        assert atts[0].width == 1280
+
+    def test_document(self):
+        from chatom.telegram.message import _telegram_attachments
+
+        msg = SimpleNamespace(
+            photo=None,
+            document=SimpleNamespace(file_id="D1", file_name="notes.pdf", mime_type="application/pdf", file_size=900),
+            video=None,
+            audio=None,
+            voice=None,
+        )
+        atts = _telegram_attachments(msg)
+        assert len(atts) == 1
+        assert atts[0].id == "D1"
+        assert atts[0].filename == "notes.pdf"
+        assert atts[0].attachment_type == AttachmentType.DOCUMENT
+
+    def test_none(self):
+        from chatom.telegram.message import _telegram_attachments
+
+        msg = SimpleNamespace(photo=None, document=None, video=None, audio=None, voice=None)
+        assert _telegram_attachments(msg) == []
+
+
+class TestSymphonyIncomingAttachments:
+    def test_attachment_metadata_carries_ids(self):
+        from chatom.symphony.backend import _symphony_attachments
+
+        infos = [
+            SimpleNamespace(id="A1", name="diagram.png", size=4000, images=None),
+            SimpleNamespace(id="A2", name="spec.pdf", size=8000, images=None),
+        ]
+        atts = _symphony_attachments(infos, stream_id="STREAM1", message_id="MSG1")
+        assert len(atts) == 2
+        img = atts[0]
+        assert img.attachment_type == AttachmentType.IMAGE
+        assert img.id == "A1"
+        # The stream/message IDs required to download are stored in metadata.
+        assert img.metadata == {"stream_id": "STREAM1", "message_id": "MSG1"}
+        doc = atts[1]
+        assert doc.attachment_type == AttachmentType.DOCUMENT
+        assert doc.metadata["message_id"] == "MSG1"
+
+    def test_empty(self):
+        from chatom.symphony.backend import _symphony_attachments
+
+        assert _symphony_attachments(None, "s", "m") == []

--- a/chatom/tests/test_mcp.py
+++ b/chatom/tests/test_mcp.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Union
 import pytest
 from fastmcp import Client
 
-from chatom.base import Channel, Message, User
+from chatom.base import Channel, Image, Message, User
 from chatom.base.capabilities import (
     SLACK_CAPABILITIES,
     BackendCapabilities,
@@ -36,6 +36,10 @@ class _MockBackend:
         self._messages = messages or {}
         self.sent: list[dict[str, Any]] = []
         self.reactions: list[dict[str, Any]] = []
+        self.uploaded: list[dict[str, Any]] = []
+        self.removed_reactions: list[dict[str, Any]] = []
+        self.deleted: list[dict[str, Any]] = []
+        self.presence_set: list[dict[str, Any]] = []
 
     async def fetch_messages(
         self,
@@ -128,6 +132,54 @@ class _MockBackend:
         ch_id = channel if isinstance(channel, str) else (channel.id if channel else "")
         self.reactions.append({"message_id": msg_id, "emoji": emoji, "channel": ch_id})
 
+    async def upload_file(
+        self,
+        channel: Union[str, Channel],
+        data: bytes,
+        filename: str = "file",
+        content_type: str = "",
+        title: str = "",
+        content: str = "",
+        **kwargs: Any,
+    ) -> Message:
+        ch_id = channel if isinstance(channel, str) else channel.id
+        self.uploaded.append({"channel": ch_id, "data": data, "filename": filename, "content_type": content_type})
+        return Message(id="uploaded_1", content=content, channel=Channel(id=ch_id))
+
+    async def download_attachment(self, attachment: Any, *, message: Optional[Message] = None) -> bytes:
+        if attachment.data is not None:
+            return attachment.data
+        return f"bytes:{getattr(attachment, 'id', '')}".encode()
+
+    async def get_bot_info(self) -> Optional[User]:
+        return User(id="BOT1", name="Test Bot", handle="testbot")
+
+    async def get_presence(self, user: Union[str, User]) -> Any:
+        uid = user if isinstance(user, str) else user.id
+        return {"user_id": uid, "status": "available"}
+
+    async def remove_reaction(
+        self,
+        message: Union[str, Message],
+        emoji: str,
+        channel: Optional[Union[str, Channel]] = None,
+    ) -> None:
+        msg_id = message if isinstance(message, str) else message.id
+        ch_id = channel if isinstance(channel, str) else (channel.id if channel else "")
+        self.removed_reactions.append({"message_id": msg_id, "emoji": emoji, "channel": ch_id})
+
+    async def delete_message(
+        self,
+        message: Union[str, Message],
+        channel: Optional[Union[str, Channel]] = None,
+    ) -> None:
+        msg_id = message if isinstance(message, str) else message.id
+        ch_id = channel if isinstance(channel, str) else (channel.id if channel else "")
+        self.deleted.append({"message_id": msg_id, "channel": ch_id})
+
+    async def set_presence(self, status: str, status_text: Optional[str] = None, **kwargs: Any) -> None:
+        self.presence_set.append({"status": status, "status_text": status_text})
+
 
 @pytest.fixture
 def alice() -> User:
@@ -200,7 +252,16 @@ class TestBuildMcpServer:
             assert "send_message" not in tool_names
             assert "edit_message" not in tool_names
             assert "add_reaction" not in tool_names
+            assert "remove_reaction" not in tool_names
+            assert "delete_message" not in tool_names
+            assert "set_presence" not in tool_names
+            assert "upload_file" not in tool_names
             assert "read_channel_history" in tool_names
+            # Read-side tools remain available in read-only mode.
+            assert "list_recent_attachments" in tool_names
+            assert "download_attachment" in tool_names
+            assert "get_bot_info" in tool_names
+            assert "get_presence" in tool_names
 
     @pytest.mark.asyncio
     async def test_capability_gating(self) -> None:
@@ -214,6 +275,72 @@ class TestBuildMcpServer:
             assert "edit_message" not in tool_names
             assert "add_reaction" not in tool_names
             assert "read_channel_history" in tool_names
+            # get_bot_info has no capability requirement — always available.
+            assert "get_bot_info" in tool_names
+            # No PRESENCE/DELETING/EMOJI capability → those tools are gated off.
+            assert "get_presence" not in tool_names
+            assert "set_presence" not in tool_names
+            assert "delete_message" not in tool_names
+            assert "remove_reaction" not in tool_names
+            # No FILES/IMAGES capability → attachment tools are gated off.
+            assert "list_recent_attachments" not in tool_names
+            assert "download_attachment" not in tool_names
+            assert "upload_file" not in tool_names
+
+    @pytest.mark.asyncio
+    async def test_attachment_tools_present_with_files(self, mock_backend: _MockBackend) -> None:
+        mcp = build_mcp_server({"mock": mock_backend})
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            tool_names = {t.name for t in tools}
+            assert "list_recent_attachments" in tool_names
+            assert "download_attachment" in tool_names
+            assert "upload_file" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_new_tools_present_with_slack_caps(self, mock_backend: _MockBackend) -> None:
+        mcp = build_mcp_server({"mock": mock_backend})
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            tool_names = {t.name for t in tools}
+            assert "get_bot_info" in tool_names
+            assert "get_presence" in tool_names
+            assert "remove_reaction" in tool_names
+            assert "delete_message" in tool_names
+            assert "set_presence" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_disabled_tools_denylist(self, mock_backend: _MockBackend) -> None:
+        mcp = build_mcp_server({"mock": mock_backend}, disabled_tools={"delete_message", "set_presence"})
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            tool_names = {t.name for t in tools}
+            assert "delete_message" not in tool_names
+            assert "set_presence" not in tool_names
+            # Other tools remain.
+            assert "remove_reaction" in tool_names
+            assert "send_message" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_enabled_tools_allowlist(self, mock_backend: _MockBackend) -> None:
+        mcp = build_mcp_server({"mock": mock_backend}, enabled_tools={"read_channel_history", "get_bot_info"})
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            tool_names = {t.name for t in tools}
+            assert tool_names == {"read_channel_history", "get_bot_info"}
+
+    @pytest.mark.asyncio
+    async def test_disabled_wins_over_enabled(self, mock_backend: _MockBackend) -> None:
+        mcp = build_mcp_server(
+            {"mock": mock_backend},
+            enabled_tools={"read_channel_history", "delete_message"},
+            disabled_tools={"delete_message"},
+        )
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            tool_names = {t.name for t in tools}
+            assert "read_channel_history" in tool_names
+            assert "delete_message" not in tool_names
 
 
 class TestMcpClientIntegration:
@@ -272,6 +399,77 @@ class TestMcpClientIntegration:
                 {"message_id": "m1", "emoji": "thumbsup", "channel": {"id": "C1"}},
             )
             assert mock_backend.reactions[0]["emoji"] == "thumbsup"
+
+    @pytest.mark.asyncio
+    async def test_get_bot_info(self, mock_backend: _MockBackend) -> None:
+        mcp = build_mcp_server({"mock": mock_backend})
+        async with Client(mcp) as client:
+            result = await client.call_tool("get_bot_info", {})
+            data = result.data if hasattr(result, "data") and result.data is not None else result
+            assert data["id"] == "BOT1"
+            assert data["handle"] == "testbot"
+
+    @pytest.mark.asyncio
+    async def test_remove_reaction(self, mock_backend: _MockBackend) -> None:
+        mcp = build_mcp_server({"mock": mock_backend})
+        async with Client(mcp) as client:
+            _ = await client.call_tool(
+                "remove_reaction",
+                {"message_id": "m1", "emoji": "thumbsup", "channel": {"id": "C1"}},
+            )
+            assert mock_backend.removed_reactions[0]["emoji"] == "thumbsup"
+
+    @pytest.mark.asyncio
+    async def test_delete_message(self, mock_backend: _MockBackend) -> None:
+        # delete_message must be explicitly enabled (off in the shipped config).
+        mcp = build_mcp_server({"mock": mock_backend})
+        async with Client(mcp) as client:
+            _ = await client.call_tool(
+                "delete_message",
+                {"message_id": "m1", "channel": {"id": "C1"}},
+            )
+            assert mock_backend.deleted[0]["message_id"] == "m1"
+
+    @pytest.mark.asyncio
+    async def test_set_presence(self, mock_backend: _MockBackend) -> None:
+        mcp = build_mcp_server({"mock": mock_backend})
+        async with Client(mcp) as client:
+            _ = await client.call_tool("set_presence", {"status": "away", "status_text": "brb"})
+            assert mock_backend.presence_set[0] == {"status": "away", "status_text": "brb"}
+
+    @pytest.mark.asyncio
+    async def test_upload_file(self, mock_backend: _MockBackend) -> None:
+        import base64
+
+        mcp = build_mcp_server({"mock": mock_backend})
+        async with Client(mcp) as client:
+            payload = base64.b64encode(b"PNGDATA").decode("ascii")
+            _ = await client.call_tool(
+                "upload_file",
+                {"channel": {"id": "C1"}, "filename": "out.png", "data_base64": payload},
+            )
+            assert mock_backend.uploaded[0]["data"] == b"PNGDATA"
+            assert mock_backend.uploaded[0]["filename"] == "out.png"
+            assert mock_backend.uploaded[0]["content_type"] == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_list_and_download_attachment(self, mock_backend: _MockBackend) -> None:
+        import base64
+
+        mock_backend._messages["C1"][0].attachments = [Image(id="att1", filename="pic.png", content_type="image/png")]
+
+        mcp = build_mcp_server({"mock": mock_backend})
+        async with Client(mcp) as client:
+            listed = await client.call_tool("list_recent_attachments", {"channel": {"id": "C1"}})
+            items = listed.structured_content["result"]
+            assert any(a["attachment_id"] == "att1" for a in items)
+
+            got = await client.call_tool(
+                "download_attachment",
+                {"attachment_id": "att1", "channel": {"id": "C1"}},
+            )
+            got_data = got.data if hasattr(got, "data") and got.data is not None else got
+            assert base64.b64decode(got_data["data_base64"]) == b"bytes:att1"
 
     @pytest.mark.asyncio
     async def test_search_messages(self, mock_backend: _MockBackend) -> None:


### PR DESCRIPTION
Add the ability to see/download received images and documents and to upload images and documents to chat.

- BackendBase.download_attachment() with a safe stdlib base impl (http(s)-only) plus per-backend auth overrides: Slack (bearer token / files.info), Telegram (getFile by file_id), Symphony (BDK get_attachment). Discord uses the public-CDN base path.
- Populate Message.attachments on incoming messages for all four backends (Slack files, Discord attachments, Telegram photo/document/video/audio/voice, Symphony V4AttachmentInfo).
- Add Attachment.metadata to carry platform context (e.g. Symphony stream/message IDs) needed for downloads.
- New capability-gated tools in the agent toolset and MCP server: list_recent_attachments, download_attachment, upload_file.
- Tests for download, incoming extraction, and the new agent/MCP tools.