### PR TITLE
Range-aware message history, newest-first, and Symphony fixes

### DIFF
--- a/chatom/agent/toolset.py
+++ b/chatom/agent/toolset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Set, cast
 
 from pydantic import BaseModel as PydanticBaseModel, Field, TypeAdapter
@@ -15,6 +15,35 @@ from chatom.base import Channel, ChannelType, User
 from chatom.base.capabilities import Capability
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_history_bounds(
+    after: Any = None,
+    before: Any = None,
+    last_minutes: Any = None,
+) -> "tuple[Optional[datetime], Optional[datetime]]":
+    """Resolve history-range args to an ``(after, before)`` datetime pair.
+
+    ``after``/``before`` may be ISO-8601 strings (``Z`` accepted); ``last_minutes``
+    is a convenience lower bound of *now* minus N minutes. Either result may be
+    None. Shared by the agent toolset and the MCP server so both surfaces expose
+    identical range semantics.
+    """
+
+    def _parse(value: Any) -> Optional[datetime]:
+        if not value:
+            return None
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        dt = datetime.fromisoformat(str(value).strip().replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+    after_dt = _parse(after)
+    before_dt = _parse(before)
+    if last_minutes:
+        window_start = datetime.now(timezone.utc) - timedelta(minutes=int(last_minutes))
+        after_dt = window_start if after_dt is None else max(after_dt, window_start)
+    return after_dt, before_dt
 
 
 class AccessDeniedError(Exception):
@@ -106,7 +135,20 @@ class ReadChannelHistoryParams(PydanticBaseModel):
     """Parameters for reading message history from a channel."""
 
     channel: ChannelRef = Field(description="Channel to read messages from. Provide at least channel ID or name.")
-    limit: int = Field(default=50, description="Maximum number of messages to fetch (1-200).", ge=1, le=200)
+    limit: int = Field(default=50, description="Maximum number of messages to return, newest first (1-200).", ge=1, le=200)
+    last_minutes: Optional[int] = Field(
+        default=None,
+        description="Only messages from the last N minutes (e.g. 30 for the last half hour). Use this for recency without needing the current time.",
+        ge=1,
+    )
+    after: Optional[str] = Field(
+        default=None,
+        description="Only messages at or after this ISO-8601 UTC timestamp (e.g. '2026-07-17T18:51:00Z'). Lower bound of a range.",
+    )
+    before: Optional[str] = Field(
+        default=None,
+        description="Only messages at or before this ISO-8601 UTC timestamp. Upper bound of a range.",
+    )
 
 
 class SearchMessagesParams(PydanticBaseModel):
@@ -228,8 +270,11 @@ _TOOL_DESCRIPTORS: list[dict[str, Any]] = [
     {
         "name": "read_channel_history",
         "description": (
-            "Read recent message history from a chat channel. "
-            "Returns messages ordered oldest-to-newest. "
+            "Read message history from a chat channel. "
+            "Returns messages ordered newest-to-oldest. "
+            "Fetch the most recent messages by count with 'limit', a recent "
+            "window with 'last_minutes' (e.g. 30), or a specific range with "
+            "'after'/'before' ISO-8601 UTC timestamps. "
             "Each message includes the author, content, timestamp, and ID."
         ),
         "params_model": ReadChannelHistoryParams,
@@ -547,21 +592,23 @@ class BackendToolset(AbstractToolset[Any]):
         """
         policy = self._policy
         channel_id = channel.id
+        normalize = self._backend.normalize_channel_id
+        norm_id = normalize(channel_id) if channel_id else channel_id
 
         # 1. Blocked channels — always denied
-        if channel_id and channel_id in policy.blocked_channel_ids:
+        if channel_id and norm_id in {normalize(c) for c in policy.blocked_channel_ids}:
             raise AccessDeniedError(f"Access to channel '{channel_id}' is blocked by policy.")
 
         # 2. Explicit whitelist — if set, only listed channels are allowed
         if policy.allowed_channel_ids is not None:
-            if channel_id not in policy.allowed_channel_ids:
+            if norm_id not in {normalize(c) for c in policy.allowed_channel_ids}:
                 raise AccessDeniedError(f"Channel '{channel_id}' is not in the allowed channel list.")
             # If whitelisted, skip further checks (admin explicitly allowed)
             return
 
         # 3. Restrict to invoking channel
         if policy.restrict_to_invoking_channel and policy.invoking_channel_id:
-            if channel_id and channel_id != policy.invoking_channel_id:
+            if channel_id and norm_id != normalize(policy.invoking_channel_id):
                 raise AccessDeniedError(f"Access restricted to the invoking channel. Cannot read from channel '{channel.name or channel_id}'.")
 
         # 4. Block DM reads
@@ -710,9 +757,12 @@ class BackendToolset(AbstractToolset[Any]):
         channel = await self._resolve_channel_full(channel)
         await self._check_channel_access(channel)
         limit = min(args.get("limit", 50), self._policy.max_messages_per_request)
+        after, before = resolve_history_bounds(args.get("after"), args.get("before"), args.get("last_minutes"))
         messages = await self._backend.fetch_messages(
             channel=channel,
             limit=limit,
+            after=after,
+            before=before,
         )
         if isinstance(messages, list):
             messages = self._filter_messages_by_time(messages)

--- a/chatom/backend/backend.py
+++ b/chatom/backend/backend.py
@@ -6,6 +6,7 @@ This module provides the base class that all backends must implement.
 import asyncio
 from abc import abstractmethod
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from functools import cached_property
 from threading import Lock
 from typing import (
@@ -249,6 +250,22 @@ class BackendBase(BaseModel):
             The Format enum value for this backend.
         """
         return self.__class__.format
+
+    def normalize_channel_id(self, channel_id: str) -> str:
+        """Return a canonical form of a channel id for equality comparison.
+
+        Some platforms expose the same channel under multiple equivalent id
+        encodings. Backends where that happens should override this to return
+        a single canonical form so that equal channels compare equal. The
+        default returns the id unchanged.
+
+        Args:
+            channel_id: The channel id to canonicalize.
+
+        Returns:
+            The canonical channel id.
+        """
+        return channel_id
 
     # Connection methods
 
@@ -791,27 +808,39 @@ class BackendBase(BaseModel):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[str] = None,
-        after: Optional[str] = None,
+        before: Optional[Union[str, "Message", datetime]] = None,
+        after: Optional[Union[str, "Message", datetime]] = None,
     ) -> List[Message]:
-        """Fetch messages from a channel.
+        """Fetch messages from a channel, newest-first.
 
-        Retrieves historical messages from the specified channel.
+        Returns up to ``limit`` messages, ordered newest-to-oldest. ``before``
+        and ``after`` bound the range; each accepts a message id, a
+        :class:`Message`, or a timezone-aware :class:`~datetime.datetime`:
+
+        - ``after``: only messages at or after this point (lower bound).
+        - ``before``: only messages at or before this point (upper bound).
+
+        When a range is given, implementations page the underlying API to
+        cover the whole range without dropping messages (subject to
+        ``limit``); when no range is given, they return the most recent
+        ``limit`` messages.
 
         Args:
             channel: The channel to fetch messages from (ID string or Channel object).
-            limit: Maximum number of messages to fetch.
-            before: Fetch messages before this message ID (for pagination).
-            after: Fetch messages after this message ID (for pagination).
+            limit: Maximum number of messages to return.
+            before: Upper bound — message id, Message, or datetime.
+            after: Lower bound — message id, Message, or datetime.
 
         Returns:
-            List of messages, ordered from oldest to newest.
+            List of messages, ordered newest-to-oldest.
 
         Example:
-            >>> # All of these work:
-            >>> msgs = await backend.fetch_messages("C123")
-            >>> msgs = await backend.fetch_messages(Channel(id="C123"))
-            >>> msgs = await backend.fetch_messages(Channel(name="general"))  # Resolves
+            >>> # Most recent 50:
+            >>> msgs = await backend.fetch_messages("C123", limit=50)
+            >>> # Everything in the last 30 minutes:
+            >>> from datetime import datetime, timedelta, timezone
+            >>> since = datetime.now(timezone.utc) - timedelta(minutes=30)
+            >>> msgs = await backend.fetch_messages("C123", after=since)
         """
         raise NotImplementedError("Subclass must implement fetch_messages()")
 

--- a/chatom/discord/backend.py
+++ b/chatom/discord/backend.py
@@ -444,19 +444,19 @@ class DiscordBackend(BackendBase):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[Union[str, Message]] = None,
-        after: Optional[Union[str, Message]] = None,
+        before: Optional[Union[str, Message, datetime]] = None,
+        after: Optional[Union[str, Message, datetime]] = None,
     ) -> List[Message]:
-        """Fetch messages from a Discord channel.
+        """Fetch messages from a Discord channel, newest-first.
 
         Args:
             channel: The channel to fetch messages from (ID string or Channel object).
-            limit: Maximum number of messages (1-100).
-            before: Fetch messages before this message (ID string or Message object).
-            after: Fetch messages after this message (ID string or Message object).
+            limit: Maximum number of messages to return.
+            before: Upper bound — message id, Message, or datetime.
+            after: Lower bound — message id, Message, or datetime.
 
         Returns:
-            List of messages.
+            List of messages, ordered newest-to-oldest.
         """
         if self._client is None:
             raise RuntimeError("Not connected to Discord")
@@ -464,32 +464,21 @@ class DiscordBackend(BackendBase):
         # Resolve channel ID
         channel_id = await self._resolve_channel_id(channel)
 
-        # Resolve before/after message IDs
-        before_id = None
-        if before:
-            if isinstance(before, Message):
-                before_id = before.id
-            else:
-                before_id = before
-
-        after_id = None
-        if after:
-            if isinstance(after, Message):
-                after_id = after.id
-            else:
-                after_id = after
-
         try:
             discord_channel = await self._client.fetch_channel(int(channel_id))
             if discord_channel is None:
                 return []
 
-            # Build kwargs for history()
-            kwargs: dict[str, Any] = {"limit": min(limit, 100)}
-            if before_id:
-                kwargs["before"] = discord.Object(id=int(before_id))
-            if after_id:
-                kwargs["after"] = discord.Object(id=int(after_id))
+            # discord.py history() accepts datetimes directly, and snowflake
+            # objects for message-id bounds. oldest_first=False keeps the
+            # newest-to-oldest ordering even when an `after` bound is set.
+            kwargs: dict[str, Any] = {"limit": limit, "oldest_first": False}
+            before_bound = self._discord_bound(before)
+            after_bound = self._discord_bound(after)
+            if before_bound is not None:
+                kwargs["before"] = before_bound
+            if after_bound is not None:
+                kwargs["after"] = after_bound
 
             messages: List[Message] = []
             async for msg in discord_channel.history(**kwargs):
@@ -505,9 +494,20 @@ class DiscordBackend(BackendBase):
                 )
                 messages.append(message)
 
-            return messages
+            messages.sort(key=lambda m: m.created_at or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
+            return messages[:limit]
         except (discord.NotFound, discord.HTTPException, ValueError) as e:
             raise RuntimeError(f"Failed to fetch messages: {e}") from e
+
+    @staticmethod
+    def _discord_bound(value: Optional[Union[str, Message, datetime]]) -> Any:
+        """Coerce a range bound to a value ``history()`` accepts, or None."""
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        message_id = value.id if isinstance(value, Message) else value
+        return discord.Object(id=int(message_id))
 
     async def search_messages(
         self,

--- a/chatom/discord/testing.py
+++ b/chatom/discord/testing.py
@@ -425,8 +425,8 @@ class MockDiscordBackend(DiscordBackend):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[Union[str, Message]] = None,
-        after: Optional[Union[str, Message]] = None,
+        before: Optional[Union[str, Message, datetime]] = None,
+        after: Optional[Union[str, Message, datetime]] = None,
     ) -> List[Message]:
         """Fetch mock messages from a channel.
 
@@ -442,17 +442,22 @@ class MockDiscordBackend(DiscordBackend):
         channel_id = channel.id if isinstance(channel, Channel) else str(channel)
         messages = self._mock_messages.get(channel_id, [])
 
-        # Extract ID strings from Message objects if needed
-        before_id = before.id if isinstance(before, Message) else before
-        after_id = after.id if isinstance(after, Message) else after
+        # Extract a comparable snowflake id; datetime bounds are not modeled here.
+        def _to_id(value):
+            if value is None or isinstance(value, datetime):
+                return None
+            return int(value.id if isinstance(value, Message) else value)
+
+        before_id = _to_id(before)
+        after_id = _to_id(after)
 
         # Apply before filter
-        if before_id:
-            messages = [m for m in messages if int(m.id) < int(before_id)]
+        if before_id is not None:
+            messages = [m for m in messages if int(m.id) < before_id]
 
         # Apply after filter
-        if after_id:
-            messages = [m for m in messages if int(m.id) > int(after_id)]
+        if after_id is not None:
+            messages = [m for m in messages if int(m.id) > after_id]
 
         # Sort by ID descending (newest first) and limit
         messages = sorted(messages, key=lambda m: int(m.id), reverse=True)

--- a/chatom/mcp/cli.py
+++ b/chatom/mcp/cli.py
@@ -52,7 +52,7 @@ def main() -> None:
     transport_value: str = cfg.server.transport
     if transport_value not in ("stdio", "http", "sse", "streamable-http"):
         raise SystemExit(f"error: unsupported transport: {transport_value}")
-    transport = cast(Transport, transport_value)
+    transport: Transport = transport_value
     if cfg.server.auth_token_env and transport != "stdio":
         auth_token = os.environ.get(cfg.server.auth_token_env, "")
         if auth_token:

--- a/chatom/mcp/server.py
+++ b/chatom/mcp/server.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
+from chatom.agent.toolset import resolve_history_bounds
 from chatom.backend import BackendBase
 from chatom.base import Channel, User
 from chatom.base.capabilities import Capability
@@ -123,10 +124,14 @@ def _register_backend_tools(
     @_tool("read_channel_history")
     async def read_channel_history(
         channel: ChannelRef = Field(description="Channel to read messages from."),
-        limit: int = Field(default=50, description="Maximum messages (1-200).", ge=1, le=200),
+        limit: int = Field(default=50, description="Maximum messages, newest first (1-200).", ge=1, le=200),
+        last_minutes: Optional[int] = Field(default=None, description="Only messages from the last N minutes (e.g. 30).", ge=1),
+        after: Optional[str] = Field(default=None, description="Only messages at/after this ISO-8601 UTC timestamp."),
+        before: Optional[str] = Field(default=None, description="Only messages at/before this ISO-8601 UTC timestamp."),
     ) -> list[dict[str, Any]]:
-        """Read recent message history from a chat channel."""
-        msgs = await backend.fetch_messages(channel=channel.to_channel(), limit=limit)
+        """Read message history from a chat channel, newest-first."""
+        after_dt, before_dt = resolve_history_bounds(after, before, last_minutes)
+        msgs = await backend.fetch_messages(channel=channel.to_channel(), limit=limit, after=after_dt, before=before_dt)
         return _serialize(msgs)
 
     @_tool("search_messages", cap=Capability.MESSAGE_SEARCH)

--- a/chatom/slack/backend.py
+++ b/chatom/slack/backend.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import getLogger
 from typing import Any, AsyncIterator, ClassVar, List, Optional, Union
 
@@ -451,59 +451,67 @@ class SlackBackend(BackendBase):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[str] = None,
-        after: Optional[str] = None,
+        before: Optional[Union[str, Message, datetime]] = None,
+        after: Optional[Union[str, Message, datetime]] = None,
     ) -> List[Message]:
-        """Fetch messages from a Slack channel.
+        """Fetch messages from a Slack channel, newest-first.
 
-        Uses the conversations.history API.
+        Uses the conversations.history API with ``oldest``/``latest`` bounds,
+        paging via cursor to cover the full range up to ``limit``.
 
         Args:
             channel: The channel to fetch messages from (ID string or Channel object).
-            limit: Maximum number of messages (1-1000).
-            before: Fetch messages before this timestamp/message (latest).
-            after: Fetch messages after this timestamp/message (oldest).
+            limit: Maximum number of messages to return.
+            before: Upper bound — Slack ts, Message, or datetime (``latest``).
+            after: Lower bound — Slack ts, Message, or datetime (``oldest``).
 
         Returns:
-            List of messages, newest first.
+            List of messages, ordered newest-to-oldest.
         """
         self._ensure_connected()
 
         # Resolve channel ID
         channel_id = await self._resolve_channel_id(channel)
 
-        # Resolve before/after message IDs
-        before_ts = None
-        if before:
-            if isinstance(before, SlackMessage):
-                before_ts = before.id
-            else:
-                before_ts = before
+        latest = self._to_slack_ts(before)
+        oldest = self._to_slack_ts(after)
 
-        after_ts = None
-        if after:
-            if isinstance(after, SlackMessage):
-                after_ts = after.id
-            else:
-                after_ts = after
+        messages: List[Message] = []
+        cursor: Optional[str] = None
+        while len(messages) < limit:
+            kwargs: dict = {"channel": channel_id, "limit": min(limit - len(messages), 1000)}
+            if latest:
+                kwargs["latest"] = latest
+            if oldest:
+                kwargs["oldest"] = oldest
+            if cursor:
+                kwargs["cursor"] = cursor
 
-        kwargs: dict = {"channel": channel_id, "limit": min(limit, 1000)}
-        if before_ts:
-            kwargs["latest"] = before_ts
-        if after_ts:
-            kwargs["oldest"] = after_ts
+            response = await self._async_client.conversations_history(**kwargs)
+            if not response.get("ok"):
+                raise RuntimeError(f"Failed to fetch messages: {response.get('error')}")
 
-        response = await self._async_client.conversations_history(**kwargs)
+            for msg_data in response.get("messages", []):
+                messages.append(self._parse_slack_message(msg_data, channel_id))
 
-        if not response.get("ok"):
-            raise RuntimeError(f"Failed to fetch messages: {response.get('error')}")
+            cursor = (response.get("response_metadata") or {}).get("next_cursor")
+            if not response.get("has_more") or not cursor:
+                break
 
-        messages = []
-        for msg_data in response.get("messages", []):
-            messages.append(self._parse_slack_message(msg_data, channel_id))
+        # Slack returns newest-first within and across cursor pages.
+        return messages[:limit]
 
-        # Slack returns newest first, reverse for oldest first
-        return list(reversed(messages))
+    @staticmethod
+    def _to_slack_ts(value: Optional[Union[str, Message, datetime]]) -> Optional[str]:
+        """Coerce a range bound to a Slack ``ts`` string, or None."""
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+            return f"{dt.timestamp():.6f}"
+        if isinstance(value, SlackMessage):
+            return value.id
+        return str(value)
 
     async def search_messages(
         self,

--- a/chatom/slack/testing.py
+++ b/chatom/slack/testing.py
@@ -4,7 +4,7 @@ This module provides a mock implementation of the Slack backend
 for use in tests without requiring actual Slack API credentials.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
 from ..base import Avatar, Channel, Message, MessageType, PresenceStatus, Thread, User
@@ -423,8 +423,8 @@ class MockSlackBackend(SlackBackend):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[str] = None,
-        after: Optional[str] = None,
+        before: Optional[Union[str, Message, datetime]] = None,
+        after: Optional[Union[str, Message, datetime]] = None,
     ) -> List[Message]:
         """Fetch mock messages from a channel.
 
@@ -440,11 +440,25 @@ class MockSlackBackend(SlackBackend):
         channel_id = channel.id if isinstance(channel, Channel) else str(channel)
         messages = self._mock_messages.get(channel_id, [])
 
+        # Coerce bounds to a comparable Slack ts string.
+        def _to_ts(value):
+            if value is None:
+                return None
+            if isinstance(value, datetime):
+                dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+                return f"{dt.timestamp():.6f}"
+            if isinstance(value, Message):
+                return value.id
+            return value
+
+        after_ts = _to_ts(after)
+        before_ts = _to_ts(before)
+
         # Filter by before/after
-        if after:
-            messages = [m for m in messages if m.ts and m.ts > after]
-        if before:
-            messages = [m for m in messages if m.ts and m.ts < before]
+        if after_ts:
+            messages = [m for m in messages if m.ts and m.ts > after_ts]
+        if before_ts:
+            messages = [m for m in messages if m.ts and m.ts < before_ts]
 
         # Sort by timestamp and limit
         messages = sorted(messages, key=lambda m: m.ts)

--- a/chatom/symphony/backend.py
+++ b/chatom/symphony/backend.py
@@ -5,6 +5,7 @@ This module provides the Symphony backend using the Symphony BDK
 """
 
 import asyncio
+import base64
 import contextlib
 import importlib
 import logging
@@ -184,6 +185,30 @@ class SymphonyBackend(BackendBase):
         """Pydantic config."""
 
         arbitrary_types_allowed = True
+
+    def normalize_channel_id(self, channel_id: str) -> str:
+        """Canonicalize a Symphony stream id for equality comparison.
+
+        Symphony returns stream ids in both standard and URL-safe base64,
+        with or without ``=`` padding, depending on which API produced them
+        (for example the datafeed vs. stream lookups). Decode whichever form
+        was given and re-encode to standard padded base64 so the same stream
+        compares equal regardless of source. Non-base64 values are returned
+        unchanged.
+
+        Args:
+            channel_id: The stream id to canonicalize.
+
+        Returns:
+            The canonical stream id.
+        """
+        if not channel_id:
+            return channel_id
+        try:
+            raw = base64.urlsafe_b64decode(channel_id + "=" * (-len(channel_id) % 4))
+            return base64.b64encode(raw).decode("ascii")
+        except (ValueError, TypeError):
+            return channel_id
 
     async def connect(self) -> None:
         """Connect to Symphony using the BDK.
@@ -554,107 +579,112 @@ class SymphonyBackend(BackendBase):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[Union[str, Message]] = None,
-        after: Optional[Union[str, Message]] = None,
+        before: Optional[Union[str, Message, datetime]] = None,
+        after: Optional[Union[str, Message, datetime]] = None,
     ) -> List[Message]:
-        """Fetch messages from a Symphony stream.
+        """Fetch messages from a Symphony stream, newest-first.
 
-        When neither *before* nor *after* is specified, retrieves the most
-        recent *limit* messages by paginating backward in time windows.
+        Returns up to *limit* messages ordered newest-to-oldest. ``after`` and
+        ``before`` bound the range and accept a millisecond-epoch id string, a
+        :class:`Message` (its ``created_at`` is used), or a
+        :class:`~datetime.datetime`. The stream is paged in full over the
+        bounded range (Symphony's API returns oldest-first from a ``since``
+        timestamp; we widen/skip to cover everything) before trimming to the
+        most recent *limit*.
 
         Args:
-            channel: The stream to fetch messages from (ID string or Channel object).
+            channel: The stream to fetch from (ID string or Channel object).
             limit: Maximum number of messages to return.
-            before: Fetch messages before this message (ID string or Message object).
-            after: Fetch messages after this message (ID string or Message object).
+            before: Upper bound — epoch-ms id, Message, or datetime.
+            after: Lower bound — epoch-ms id, Message, or datetime.
 
         Returns:
-            List of messages, ordered oldest-first.
+            List of messages, ordered newest-to-oldest.
         """
         if self._bdk is None:
             raise RuntimeError("Symphony not connected")
 
-        # Resolve channel ID
         channel_id = await self._resolve_channel_id(channel)
+        since_ms = self._to_epoch_ms(after)
+        until_ms = self._to_epoch_ms(before)
+        return await self._fetch_range(channel_id, limit, since_ms, until_ms)
 
-        # Resolve after message ID / timestamp
-        after_id = None
-        if after:
-            if isinstance(after, Message):
-                after_id = after.id
-            else:
-                after_id = after
+    @staticmethod
+    def _to_epoch_ms(value: Optional[Union[str, Message, datetime]]) -> Optional[int]:
+        """Coerce a range bound to a millisecond epoch, or None."""
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp() * 1000)
+        if isinstance(value, Message):
+            return int(value.created_at.timestamp() * 1000) if value.created_at else None
+        return int(value)
 
-        if after_id:
-            # Simple case: fetch from a known point forward
-            return await self._fetch_messages_since(channel_id, since_ms=int(after_id), limit=limit)
+    async def _fetch_range(
+        self,
+        channel_id: str,
+        limit: int,
+        since_ms: Optional[int],
+        until_ms: Optional[int],
+    ) -> List[Message]:
+        """Collect every message in the ``[since_ms, until_ms]`` range, then
+        return the most recent *limit* of them, newest-first.
 
-        # Default: get the most recent `limit` messages by paging backward
-        return await self._fetch_recent_messages(channel_id, limit)
-
-    async def _fetch_messages_since(self, channel_id: str, since_ms: int, limit: int) -> List[Message]:
-        """Fetch up to *limit* messages after a given timestamp."""
-        message_service = self._bdk.messages()
-        try:
-            messages_data = await message_service.list_messages(stream_id=channel_id, since=since_ms, limit=limit)
-        except Exception as e:
-            raise RuntimeError(f"Failed to fetch messages: {e}") from e
-        return self._convert_messages(messages_data, channel_id)
-
-    async def _fetch_recent_messages(self, channel_id: str, limit: int) -> List[Message]:
-        """Page backward in time to collect the most recent *limit* messages.
-
-        Strategy:
-        The Symphony API returns oldest-first from a given ``since`` timestamp.
-        To get the most recent N messages we widen a lookback window starting
-        from 1 hour, doubling each iteration until we've captured at least
-        ``limit`` messages (or hit the 90-day backstop).  Within each window
-        we use ``skip``-based pagination to fetch ALL messages.
+        Symphony's ``list_messages`` returns oldest-first from a ``since``
+        timestamp, so we skip-paginate a lower bound to fetch all messages,
+        widening the lower bound in growing windows when the caller gave no
+        ``after`` bound.
         """
         message_service = self._bdk.messages()
         now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
         page_limit = 500  # Symphony API max per request
         max_backstop_ms = now_ms - int(timedelta(days=90).total_seconds() * 1000)
 
-        window_hours = 1
-        while True:
-            window_start_ms = now_ms - int(window_hours * 3600 * 1000)
-            if window_start_ms < max_backstop_ms:
-                window_start_ms = max_backstop_ms
-
-            # Fetch ALL messages from window_start to now via skip pagination
-            all_in_window: list = []
+        async def page_from(start_ms: int) -> list:
+            """Fetch ALL messages at/after ``start_ms`` via skip pagination."""
+            collected: list = []
             skip = 0
             while True:
                 try:
                     batch = await message_service.list_messages(
                         stream_id=channel_id,
-                        since=window_start_ms,
+                        since=start_ms,
                         skip=skip,
                         limit=page_limit,
                     )
                 except Exception as e:
                     raise RuntimeError(f"Failed to fetch messages: {e}") from e
-
                 if not batch:
                     break
-                all_in_window.extend(batch)
+                collected.extend(batch)
                 if len(batch) < page_limit:
-                    break  # got everything in this window
+                    break
                 skip += len(batch)
+            return collected
 
-            if len(all_in_window) >= limit:
-                # We have enough — convert and take the most recent `limit`
-                messages = self._convert_messages(all_in_window, channel_id)
-                return messages[-limit:]
+        if since_ms is not None:
+            raw = await page_from(max(since_ms, max_backstop_ms))
+        else:
+            # No lower bound: widen a lookback window until we have >= limit.
+            window_hours = 1
+            raw = []
+            while True:
+                start = now_ms - int(window_hours * 3600 * 1000)
+                if start < max_backstop_ms:
+                    start = max_backstop_ms
+                raw = await page_from(start)
+                if len(raw) >= limit or start <= max_backstop_ms:
+                    break
+                window_hours = min(window_hours * 2, 24 * 90)
 
-            if window_start_ms <= max_backstop_ms:
-                # Hit the backstop — return whatever we have
-                messages = self._convert_messages(all_in_window, channel_id)
-                return messages[-limit:] if len(messages) > limit else messages
-
-            # Not enough — widen the window and retry
-            window_hours = min(window_hours * 2, 24 * 90)
+        messages = self._convert_messages(raw, channel_id)
+        if since_ms is not None:
+            messages = [m for m in messages if m.created_at and int(m.created_at.timestamp() * 1000) >= since_ms]
+        if until_ms is not None:
+            messages = [m for m in messages if m.created_at and int(m.created_at.timestamp() * 1000) <= until_ms]
+        messages.sort(key=lambda m: m.created_at or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
+        return messages[:limit]
 
     def _convert_messages(self, messages_data: list, channel_id: str) -> List[Message]:
         """Convert raw V4Message objects to SymphonyMessage instances."""
@@ -1532,24 +1562,18 @@ class SymphonyBackend(BackendBase):
                 try:
                     stream_type = SymphonyStreamType(stream_type_str)
                 except ValueError:
-                    stream_type = None
+                    stream_type = SymphonyStreamType.ROOM
 
-                # Lookup channel to get full info (id AND name)
-                channel = await self._backend._fetch_channel_by_id(stream_id)
-                if channel is None and stream_type is not None:
-                    # Create channel with at least the stream_type
-                    channel = SymphonyChannel(
-                        id=stream_id,
-                        name="",  # Name not available in event
-                        stream_type=stream_type,
-                    )
-                elif channel is not None and stream_type is not None:
-                    # Update stream_type if we have it
-                    channel = SymphonyChannel(
-                        id=channel.id,
-                        name=channel.name,
-                        stream_type=stream_type,
-                    )
+                # Look up the channel for its name, but always keep the stream
+                # id: _fetch_channel_by_id can return None (get_stream may fail
+                # or be denied), and the message must still carry the channel it
+                # came from so downstream consumers know the invoking channel.
+                looked_up = await self._backend._fetch_channel_by_id(stream_id)
+                channel = SymphonyChannel(
+                    id=stream_id,
+                    name=(looked_up.name if looked_up else "") or "",
+                    stream_type=stream_type,
+                )
 
                 # Lookup author to get full info (id AND name)
                 author = None

--- a/chatom/symphony/testing.py
+++ b/chatom/symphony/testing.py
@@ -315,8 +315,8 @@ class MockSymphonyBackend(BackendBase):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[str] = None,
-        after: Optional[str] = None,
+        before: Optional[Union[str, Message, datetime]] = None,
+        after: Optional[Union[str, Message, datetime]] = None,
     ) -> List[Message]:
         """Fetch messages from a mock stream.
 
@@ -335,16 +335,21 @@ class MockSymphonyBackend(BackendBase):
 
         messages_data = self.mock_messages[channel_id]
 
+        def _to_dt(value):
+            if isinstance(value, datetime):
+                return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+            if isinstance(value, Message):
+                return value.created_at
+            return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc)
+
         # Filter by timestamp if specified
         filtered = messages_data
         if before:
-            before_ts = int(before)
-            before_dt = datetime.fromtimestamp(before_ts / 1000, tz=timezone.utc)
-            filtered = [m for m in filtered if m["timestamp"] < before_dt]
+            before_dt = _to_dt(before)
+            filtered = [m for m in filtered if before_dt and m["timestamp"] < before_dt]
         if after:
-            after_ts = int(after)
-            after_dt = datetime.fromtimestamp(after_ts / 1000, tz=timezone.utc)
-            filtered = [m for m in filtered if m["timestamp"] >= after_dt]
+            after_dt = _to_dt(after)
+            filtered = [m for m in filtered if after_dt and m["timestamp"] >= after_dt]
 
         # Sort by timestamp (newest first) and limit
         filtered = sorted(filtered, key=lambda m: m["timestamp"], reverse=True)

--- a/chatom/telegram/backend.py
+++ b/chatom/telegram/backend.py
@@ -1,6 +1,7 @@
 """Telegram backend implementation for chatom."""
 
 import asyncio
+from datetime import datetime
 from logging import getLogger
 from typing import Any, AsyncIterator, ClassVar, List, Optional, Union
 
@@ -277,8 +278,8 @@ class TelegramBackend(BackendBase):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[Union[str, Message]] = None,
-        after: Optional[Union[str, Message]] = None,
+        before: Optional[Union[str, Message, datetime]] = None,
+        after: Optional[Union[str, Message, datetime]] = None,
     ) -> List[Message]:
         """Fetch messages from a Telegram chat.
 

--- a/chatom/telegram/testing.py
+++ b/chatom/telegram/testing.py
@@ -356,20 +356,25 @@ class MockTelegramBackend(TelegramBackend):
         self,
         channel: Union[str, Channel],
         limit: int = 100,
-        before: Optional[Union[str, Message]] = None,
-        after: Optional[Union[str, Message]] = None,
+        before: Optional[Union[str, Message, datetime]] = None,
+        after: Optional[Union[str, Message, datetime]] = None,
     ) -> List[Message]:
         """Fetch mock messages from a channel."""
         channel_id = channel.id if isinstance(channel, Channel) else str(channel)
         messages = self._mock_messages.get(channel_id, [])
 
-        before_id = before.id if isinstance(before, Message) else before
-        after_id = after.id if isinstance(after, Message) else after
+        def _to_id(value):
+            if value is None or isinstance(value, datetime):
+                return None
+            return int(value.id if isinstance(value, Message) else value)
 
-        if before_id:
-            messages = [m for m in messages if int(m.id) < int(before_id)]
-        if after_id:
-            messages = [m for m in messages if int(m.id) > int(after_id)]
+        before_id = _to_id(before)
+        after_id = _to_id(after)
+
+        if before_id is not None:
+            messages = [m for m in messages if int(m.id) < before_id]
+        if after_id is not None:
+            messages = [m for m in messages if int(m.id) > after_id]
 
         messages = sorted(messages, key=lambda m: int(m.id), reverse=True)
         return list(messages[:limit])

--- a/chatom/tests/test_access_policy.py
+++ b/chatom/tests/test_access_policy.py
@@ -23,6 +23,9 @@ def _make_backend(members=None, channel_type=ChannelType.PUBLIC):
     backend = MagicMock()
     backend.name = "test"
     backend.capabilities = None
+    # Mirror BackendBase.normalize_channel_id (identity) so channel-id
+    # comparisons in the access policy behave like a real backend.
+    backend.normalize_channel_id = lambda channel_id: channel_id
 
     # fetch_channel_members
     if members is not None:

--- a/chatom/tests/test_agent.py
+++ b/chatom/tests/test_agent.py
@@ -807,3 +807,93 @@ class TestChannelContext:
         assert ctx.channel_name == "empty"
         assert len(ctx.messages) == 0
         assert len(ctx.participants) == 0
+
+
+class TestChannelIdNormalization:
+    """Symphony hands out one stream under two base64 encodings; the access
+    checks must treat both encodings of the same stream as equal."""
+
+    URL_SAFE = "rnwtyMXxNWMZZNFncwz2BH___oP7GF1WdA"
+    STANDARD = "rnwtyMXxNWMZZNFncwz2BH///oP7GF1WdA=="
+
+    def test_default_normalize_is_identity(self, mock_backend: _MockBackend) -> None:
+        assert mock_backend.normalize_channel_id("C123") == "C123"
+
+    def test_symphony_canonicalizes_encodings(self) -> None:
+        symphony = pytest.importorskip("chatom.symphony")
+        backend = symphony.SymphonyBackend(
+            config=symphony.SymphonyConfig(host="h", bot_username="u", bot_certificate_path="/x.pem"),
+        )
+        assert backend.normalize_channel_id(self.URL_SAFE) == backend.normalize_channel_id(self.STANDARD)
+
+    @pytest.mark.asyncio
+    async def test_invoking_channel_allows_other_encoding(self) -> None:
+        symphony = pytest.importorskip("chatom.symphony")
+        from chatom.agent.toolset import AccessPolicy, BackendToolset
+
+        backend = symphony.SymphonyBackend(
+            config=symphony.SymphonyConfig(host="h", bot_username="u", bot_certificate_path="/x.pem"),
+        )
+        policy = AccessPolicy(
+            invoking_channel_id=self.STANDARD,
+            restrict_to_invoking_channel=True,
+            block_dm_reads=False,
+            require_membership=False,
+        )
+        toolset = BackendToolset(backend, access_policy=policy)
+        # Same stream in the other encoding must be allowed (no raise).
+        await toolset._check_channel_access(Channel(id=self.URL_SAFE))
+
+    @pytest.mark.asyncio
+    async def test_different_channel_still_denied(self) -> None:
+        symphony = pytest.importorskip("chatom.symphony")
+        from chatom.agent.toolset import AccessDeniedError, AccessPolicy, BackendToolset
+
+        backend = symphony.SymphonyBackend(
+            config=symphony.SymphonyConfig(host="h", bot_username="u", bot_certificate_path="/x.pem"),
+        )
+        policy = AccessPolicy(
+            invoking_channel_id=self.STANDARD,
+            restrict_to_invoking_channel=True,
+            block_dm_reads=False,
+            require_membership=False,
+        )
+        toolset = BackendToolset(backend, access_policy=policy)
+        with pytest.raises(AccessDeniedError):
+            await toolset._check_channel_access(Channel(id="c29tZU90aGVyU3RyZWFt"))
+
+
+class TestResolveHistoryBounds:
+    """The shared range resolver behind read_channel_history."""
+
+    def test_none_when_empty(self):
+        from chatom.agent.toolset import resolve_history_bounds
+
+        assert resolve_history_bounds() == (None, None)
+
+    def test_iso_after_before_parsed(self):
+        from datetime import datetime, timezone
+
+        from chatom.agent.toolset import resolve_history_bounds
+
+        after, before = resolve_history_bounds(after="2026-07-17T18:51:00Z", before="2026-07-17T19:21:00+00:00")
+        assert after == datetime(2026, 7, 17, 18, 51, tzinfo=timezone.utc)
+        assert before == datetime(2026, 7, 17, 19, 21, tzinfo=timezone.utc)
+
+    def test_last_minutes_sets_recent_lower_bound(self):
+        from datetime import datetime, timezone
+
+        from chatom.agent.toolset import resolve_history_bounds
+
+        after, before = resolve_history_bounds(last_minutes=30)
+        assert before is None
+        assert after is not None
+        age = (datetime.now(timezone.utc) - after).total_seconds()
+        assert 29 * 60 <= age <= 31 * 60
+
+    def test_last_minutes_takes_more_recent_of_two_lower_bounds(self):
+        from chatom.agent.toolset import resolve_history_bounds
+
+        # An old explicit `after` is overridden by the more recent last_minutes.
+        after, _ = resolve_history_bounds(after="2000-01-01T00:00:00Z", last_minutes=30)
+        assert after.year != 2000

--- a/chatom/tests/test_symphony_fetch_messages.py
+++ b/chatom/tests/test_symphony_fetch_messages.py
@@ -1,4 +1,4 @@
-"""Tests for Symphony backend fetch_messages pagination logic."""
+"""Tests for Symphony backend fetch_messages range + pagination logic."""
 
 import asyncio
 from datetime import datetime, timedelta, timezone
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from chatom.base import Message
 from chatom.symphony.backend import SymphonyBackend
 
 
@@ -53,10 +54,8 @@ def mock_list_messages(backend):
 
 
 def _make_side_effect(all_messages):
-    """Build a side_effect that simulates the Symphony API.
-
-    Returns messages with timestamp >= since, oldest-first, paginated via skip/limit.
-    """
+    """Simulate the Symphony API: messages with timestamp >= since, oldest-first,
+    paginated via skip/limit."""
 
     async def _side_effect(stream_id, since, skip=0, limit=500):
         matching = [m for m in all_messages if m.timestamp >= since]
@@ -65,208 +64,138 @@ def _make_side_effect(all_messages):
     return _side_effect
 
 
-class TestFetchRecentMessages:
-    """Test _fetch_recent_messages pagination logic."""
+class TestFetchRange:
+    """_fetch_range: newest-first results, range bounds, full pagination."""
 
-    def test_all_messages_fit_in_first_window(self, backend, mock_list_messages):
-        """When the first 1h window has enough messages, return them directly."""
+    def test_returns_most_recent_limit_newest_first(self, backend, mock_list_messages):
         now = datetime.now(timezone.utc)
-        messages = _make_messages_in_range(
-            _ms(now - timedelta(minutes=30)),
-            _ms(now - timedelta(minutes=5)),
-            30,
-        )
-        mock_list_messages.side_effect = _make_side_effect(messages)
-
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=30))
-
-        assert len(result) == 30
-        # Verify chronological order
-        timestamps = [m.created_at for m in result]
-        assert timestamps == sorted(timestamps)
-
-    def test_messages_span_multiple_windows(self, backend, mock_list_messages):
-        """When recent window is empty, widens backward to find messages."""
-        now = datetime.now(timezone.utc)
-        # Messages are 3 days old — first few windows will be empty
-        old_messages = _make_messages_in_range(
-            _ms(now - timedelta(days=3, hours=12)),
-            _ms(now - timedelta(days=3)),
-            20,
-        )
-        mock_list_messages.side_effect = _make_side_effect(old_messages)
-
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=20))
-
-        assert len(result) == 20
-        timestamps = [m.created_at for m in result]
-        assert timestamps == sorted(timestamps)
-
-    def test_no_duplicate_messages(self, backend, mock_list_messages):
-        """Pagination must not return duplicate messages."""
-        now = datetime.now(timezone.utc)
-        all_messages = _make_messages_in_range(
-            _ms(now - timedelta(days=2)),
-            _ms(now - timedelta(hours=1)),
-            100,
-        )
+        all_messages = _make_messages_in_range(_ms(now - timedelta(minutes=30)), _ms(now - timedelta(minutes=1)), 200)
         mock_list_messages.side_effect = _make_side_effect(all_messages)
 
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=50))
-
-        ids = [m.id for m in result]
-        assert len(ids) == len(set(ids)), f"Duplicate messages: {len(ids)} total, {len(set(ids))} unique"
-
-    def test_returns_most_recent_messages(self, backend, mock_list_messages):
-        """Result should be the MOST RECENT limit messages, not the oldest."""
-        now = datetime.now(timezone.utc)
-        all_messages = _make_messages_in_range(
-            _ms(now - timedelta(minutes=30)),
-            _ms(now - timedelta(minutes=1)),
-            200,
-        )
-        mock_list_messages.side_effect = _make_side_effect(all_messages)
-
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=50))
+        result = asyncio.run(backend._fetch_range("stream123", limit=50, since_ms=None, until_ms=None))
 
         assert len(result) == 50
-        expected_ids = {m.message_id for m in all_messages[-50:]}
-        result_ids = {m.id for m in result}
-        assert result_ids == expected_ids
+        ts = [m.created_at for m in result]
+        assert ts == sorted(ts, reverse=True)  # newest-first
+        assert {m.id for m in result} == {m.message_id for m in all_messages[-50:]}
 
-    def test_fewer_messages_than_limit(self, backend, mock_list_messages):
-        """If fewer messages exist than limit, return all of them."""
+    def test_no_lower_bound_widens_window(self, backend, mock_list_messages):
         now = datetime.now(timezone.utc)
-        messages = _make_messages_in_range(
-            _ms(now - timedelta(hours=6)),
-            _ms(now - timedelta(minutes=10)),
-            15,
-        )
-        mock_list_messages.side_effect = _make_side_effect(messages)
+        old = _make_messages_in_range(_ms(now - timedelta(days=3, hours=12)), _ms(now - timedelta(days=3)), 20)
+        mock_list_messages.side_effect = _make_side_effect(old)
 
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=50))
+        result = asyncio.run(backend._fetch_range("stream123", limit=20, since_ms=None, until_ms=None))
 
-        assert len(result) == 15
+        assert len(result) == 20
+        ts = [m.created_at for m in result]
+        assert ts == sorted(ts, reverse=True)
+
+    def test_since_lower_bound(self, backend, mock_list_messages):
+        now = datetime.now(timezone.utc)
+        all_messages = _make_messages_in_range(_ms(now - timedelta(hours=2)), _ms(now - timedelta(minutes=1)), 120)
+        mock_list_messages.side_effect = _make_side_effect(all_messages)
+        since = _ms(now - timedelta(minutes=30))
+
+        result = asyncio.run(backend._fetch_range("stream123", limit=500, since_ms=since, until_ms=None))
+
+        assert result
+        assert all(_ms(m.created_at) >= since for m in result)
+
+    def test_until_upper_bound(self, backend, mock_list_messages):
+        now = datetime.now(timezone.utc)
+        all_messages = _make_messages_in_range(_ms(now - timedelta(hours=2)), _ms(now - timedelta(minutes=1)), 120)
+        mock_list_messages.side_effect = _make_side_effect(all_messages)
+        until = _ms(now - timedelta(minutes=30))
+
+        result = asyncio.run(backend._fetch_range("stream123", limit=500, since_ms=None, until_ms=until))
+
+        assert result
+        assert all(_ms(m.created_at) <= until for m in result)
+
+    def test_range_between_bounds(self, backend, mock_list_messages):
+        now = datetime.now(timezone.utc)
+        all_messages = _make_messages_in_range(_ms(now - timedelta(hours=2)), _ms(now - timedelta(minutes=1)), 120)
+        mock_list_messages.side_effect = _make_side_effect(all_messages)
+        since = _ms(now - timedelta(minutes=90))
+        until = _ms(now - timedelta(minutes=30))
+
+        result = asyncio.run(backend._fetch_range("stream123", limit=500, since_ms=since, until_ms=until))
+
+        assert result
+        assert all(since <= _ms(m.created_at) <= until for m in result)
+
+    def test_full_pagination_no_duplicates(self, backend, mock_list_messages):
+        now = datetime.now(timezone.utc)
+        all_messages = _make_messages_in_range(_ms(now - timedelta(minutes=30)), _ms(now - timedelta(minutes=1)), 800)
+        mock_list_messages.side_effect = _make_side_effect(all_messages)
+
+        result = asyncio.run(backend._fetch_range("stream123", limit=800, since_ms=None, until_ms=None))
+
+        ids = [m.id for m in result]
+        assert len(ids) == len(set(ids))
+        assert mock_list_messages.call_count >= 2  # skip pagination engaged
 
     def test_empty_channel(self, backend, mock_list_messages):
-        """Empty channel returns empty list without infinite loop."""
         mock_list_messages.side_effect = _make_side_effect([])
-
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=50))
-
+        result = asyncio.run(backend._fetch_range("stream123", limit=50, since_ms=None, until_ms=None))
         assert result == []
 
     def test_backstop_prevents_infinite_pagination(self, backend, mock_list_messages):
-        """Pagination stops at the 90-day backstop even if limit not reached."""
         mock_list_messages.side_effect = _make_side_effect([])
-
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=50))
-
+        result = asyncio.run(backend._fetch_range("stream123", limit=50, since_ms=None, until_ms=None))
         assert result == []
-        # Should not make excessive calls — window doubles each time
-        # 1h -> 2h -> 4h -> ... -> 2160h covers 90 days in ~12 doublings
         assert mock_list_messages.call_count <= 15
 
-    def test_busy_channel_with_many_messages_per_hour(self, backend, mock_list_messages):
-        """Channel with >500 messages per hour still returns correct most-recent."""
-        now = datetime.now(timezone.utc)
-        # 1000 messages in the last 30 minutes
-        all_messages = _make_messages_in_range(
-            _ms(now - timedelta(minutes=30)),
-            _ms(now - timedelta(minutes=1)),
-            1000,
-        )
-        mock_list_messages.side_effect = _make_side_effect(all_messages)
 
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=50))
+class TestToEpochMs:
+    """_to_epoch_ms coerces the range bounds."""
 
-        assert len(result) == 50
-        expected_ids = {m.message_id for m in all_messages[-50:]}
-        result_ids = {m.id for m in result}
-        assert result_ids == expected_ids
+    def test_none(self):
+        assert SymphonyBackend._to_epoch_ms(None) is None
 
-    def test_chronological_order(self, backend, mock_list_messages):
-        """Results are always in chronological (oldest-first) order."""
-        now = datetime.now(timezone.utc)
-        all_messages = _make_messages_in_range(
-            _ms(now - timedelta(days=5)),
-            _ms(now - timedelta(hours=1)),
-            80,
-        )
-        mock_list_messages.side_effect = _make_side_effect(all_messages)
+    def test_aware_datetime(self):
+        dt = datetime(2026, 7, 17, 18, 51, tzinfo=timezone.utc)
+        assert SymphonyBackend._to_epoch_ms(dt) == int(dt.timestamp() * 1000)
 
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=50))
+    def test_naive_datetime_assumed_utc(self):
+        dt = datetime(2026, 7, 17, 18, 51)
+        assert SymphonyBackend._to_epoch_ms(dt) == int(dt.replace(tzinfo=timezone.utc).timestamp() * 1000)
 
-        timestamps = [m.created_at for m in result]
-        assert timestamps == sorted(timestamps)
+    def test_message_uses_created_at(self):
+        created = datetime(2026, 7, 17, 18, 51, tzinfo=timezone.utc)
+        msg = Message(id="x", content="hi", created_at=created)
+        assert SymphonyBackend._to_epoch_ms(msg) == int(created.timestamp() * 1000)
 
-    def test_skip_pagination_within_window(self, backend, mock_list_messages):
-        """Verifies skip-based pagination fetches all messages in a large window."""
-        now = datetime.now(timezone.utc)
-        # 800 messages in the last 30 minutes — requires skip pagination
-        all_messages = _make_messages_in_range(
-            _ms(now - timedelta(minutes=30)),
-            _ms(now - timedelta(minutes=1)),
-            800,
-        )
-        mock_list_messages.side_effect = _make_side_effect(all_messages)
-
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=100))
-
-        assert len(result) == 100
-        expected_ids = {m.message_id for m in all_messages[-100:]}
-        result_ids = {m.id for m in result}
-        assert result_ids == expected_ids
-        # Should have used skip pagination (at least 2 calls for 800 messages)
-        assert mock_list_messages.call_count >= 2
-
-
-class TestFetchMessagesSince:
-    """Test _fetch_messages_since (the after= parameter path)."""
-
-    def test_fetches_from_timestamp(self, backend, mock_list_messages):
-        """Fetches messages after a given timestamp."""
-        now = datetime.now(timezone.utc)
-        messages = _make_messages_in_range(
-            _ms(now - timedelta(hours=2)),
-            _ms(now - timedelta(minutes=5)),
-            10,
-        )
-        mock_list_messages.return_value = messages
-
-        since_ms = _ms(now - timedelta(hours=3))
-        result = asyncio.run(backend._fetch_messages_since("stream123", since_ms, limit=50))
-
-        assert len(result) == 10
-        mock_list_messages.assert_called_once_with(stream_id="stream123", since=since_ms, limit=50)
+    def test_string_epoch(self):
+        assert SymphonyBackend._to_epoch_ms("1716850000000") == 1716850000000
 
 
 class TestFetchMessagesDispatch:
-    """Test the public fetch_messages method dispatch logic."""
+    """The public fetch_messages resolves bounds and returns newest-first."""
 
-    def test_with_after_string_uses_since_path(self, backend, mock_list_messages):
-        """When after= is a string timestamp, uses _fetch_messages_since."""
-        mock_list_messages.return_value = []
-
-        # Patch at class level to avoid pydantic __getattr__ issues
-        with patch(
-            "chatom.symphony.backend.SymphonyBackend._resolve_channel_id",
-            new_callable=lambda: lambda: AsyncMock(return_value="stream123"),
-        ):
-            asyncio.run(backend._fetch_messages_since("stream123", 1716850000000, limit=10))
-
-        mock_list_messages.assert_called_once_with(stream_id="stream123", since=1716850000000, limit=10)
-
-    def test_without_after_uses_recent_path(self, backend, mock_list_messages):
-        """When no after= is given, uses _fetch_recent_messages."""
+    def test_after_datetime_sets_lower_bound(self, backend, mock_list_messages):
         now = datetime.now(timezone.utc)
-        messages = _make_messages_in_range(
-            _ms(now - timedelta(minutes=10)),
-            _ms(now - timedelta(minutes=1)),
-            10,
-        )
-        mock_list_messages.side_effect = _make_side_effect(messages)
+        all_messages = _make_messages_in_range(_ms(now - timedelta(hours=2)), _ms(now - timedelta(minutes=1)), 60)
+        mock_list_messages.side_effect = _make_side_effect(all_messages)
+        cutoff = now - timedelta(minutes=30)
 
-        result = asyncio.run(backend._fetch_recent_messages("stream123", limit=10))
+        with patch.object(SymphonyBackend, "_resolve_channel_id", new=AsyncMock(return_value="stream123")):
+            result = asyncio.run(backend.fetch_messages("stream123", limit=500, after=cutoff))
+
+        assert result
+        assert all(_ms(m.created_at) >= _ms(cutoff) for m in result)
+        ts = [m.created_at for m in result]
+        assert ts == sorted(ts, reverse=True)
+
+    def test_default_returns_recent_newest_first(self, backend, mock_list_messages):
+        now = datetime.now(timezone.utc)
+        all_messages = _make_messages_in_range(_ms(now - timedelta(minutes=20)), _ms(now - timedelta(minutes=1)), 40)
+        mock_list_messages.side_effect = _make_side_effect(all_messages)
+
+        with patch.object(SymphonyBackend, "_resolve_channel_id", new=AsyncMock(return_value="stream123")):
+            result = asyncio.run(backend.fetch_messages("stream123", limit=10))
 
         assert len(result) == 10
+        ts = [m.created_at for m in result]
+        assert ts == sorted(ts, reverse=True)
+        assert {m.id for m in result} == {m.message_id for m in all_messages[-10:]}


### PR DESCRIPTION
Message fetch API:
- fetch_messages now returns newest-first and accepts before/after as a message id, Message, or datetime to bound a range; backends page the underlying API in full so no in-range messages are dropped.
- Implement across Symphony (skip-paginated range + widening lookback), Slack (cursor pagination, oldest/latest bounds, no more reversal), Discord (datetime/id bounds, newest-first); Telegram stays a no-op.
- read_channel_history (agent toolset + MCP server) gains ergonomic controls: last_minutes for a recent window, after/before ISO timestamps for a specific range, via a shared resolve_history_bounds helper.

Symphony correctness:
- Add BackendBase.normalize_channel_id (identity) and a Symphony override that canonicalizes base64 stream ids, so access checks match a stream regardless of URL-safe vs standard encoding.
- Incoming datafeed messages always carry their channel (built from the stream id) so downstream consumers know the invoking channel.